### PR TITLE
chore: init project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@
 ## Static frameworks should be downloaded separately
 Frameworks/
 
-## Xcode 13
-
+## Xcode 13 with SPM
 /.build
 /Packages
 /*.xcodeproj

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+## General
+.DS_Store
+.Trashes
+._*
+
+## Static frameworks should be downloaded separately
+Frameworks/
+
+## Xcode 13
+
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Gcc Patch
+/*.gcno
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+Carthage/Checkouts
+
+Carthage/Build/
+
+# BuildTools
+BuildTools/.build
+BuildTools/.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Logto",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Logto",
+            targets: ["Logto"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "Logto",
+            dependencies: []),
+        .testTarget(
+            name: "LogtoTests",
+            dependencies: ["Logto"]),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Logto Swift SDKs
+# Logto Swift SDK

--- a/Sources/Logto/Logto.swift
+++ b/Sources/Logto/Logto.swift
@@ -1,0 +1,6 @@
+public struct Logto {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+    }
+}

--- a/Tests/LogtoTests/LogtoTests.swift
+++ b/Tests/LogtoTests/LogtoTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import Logto
+
+final class LogtoTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(Logto().text, "Hello, World!")
+    }
+}


### PR DESCRIPTION
## Summary

Use Xcode to init Logto SDK as an SPM-compatible project.

![image](https://user-images.githubusercontent.com/14722250/148349632-b374d74a-1f8d-480d-b59d-cc82b67ed300.png)

## Reviewers

@logto-io/eng 