### PR TITLE
refactor: support all JWK types

### DIFF
--- a/Sources/Logto/Extensions/Data.swift
+++ b/Sources/Logto/Extensions/Data.swift
@@ -13,7 +13,7 @@ extension Data {
             .replacingOccurrences(of: "-", with: "+")
             .replacingOccurrences(of: "_", with: "/")
             // Base64 encoding
-            .padding(toLength: string.count + string.count % 3, withPad: "=", startingAt: 0))
+            .padding(toLength: string.count + string.count % 4, withPad: "=", startingAt: 0))
     }
 
     static func randomArray(length: Int) -> Data {

--- a/Sources/Logto/LogtoUtilities+IdToken.swift
+++ b/Sources/Logto/LogtoUtilities+IdToken.swift
@@ -1,6 +1,6 @@
 //
 //  LogtoUtilities+IdToken.swift
-//  
+//
 //
 //  Created by Gao Sun on 2022/1/17.
 //
@@ -50,14 +50,14 @@ extension LogtoUtilities {
 
         // Public key verification
         let jws = try JWS(compactSerialization: idToken)
-        
+
         guard let algorithm = jws.header.algorithm else {
             throw LogtoErrors.Verification.jwtMissingAlgorithmInHeader
         }
-        
+
         let verifiers: [Verifier] = try jwks
             .keys
-            .compactMap({
+            .compactMap {
                 // [RFC-7518](https://tools.ietf.org/html/rfc7518#section-7.4)
                 switch $0 {
                 case let publicKey as ECPublicKey:
@@ -76,9 +76,8 @@ extension LogtoUtilities {
                     throw LogtoErrors.Verification.unsupportedJwkType
                 }
                 return nil
-            })
-        
-        
+            }
+
         guard verifiers.contains(where: {
             (try? jws.validate(using: $0)) != nil ? true : false
         }) else {

--- a/Sources/Logto/LogtoUtilities+IdToken.swift
+++ b/Sources/Logto/LogtoUtilities+IdToken.swift
@@ -50,39 +50,7 @@ extension LogtoUtilities {
 
         // Public key verification
         let jws = try JWS(compactSerialization: idToken)
-
-        guard let algorithm = jws.header.algorithm else {
-            throw LogtoErrors.Verification.jwtMissingAlgorithmInHeader
-        }
-
-        let verifiers: [Verifier] = try jwks
-            .keys
-            .compactMap {
-                // [RFC-7518](https://tools.ietf.org/html/rfc7518#section-7.4)
-                switch $0 {
-                case let publicKey as ECPublicKey:
-                    if let secKey = try? publicKey.converted(to: SecKey.self) {
-                        return Verifier(verifyingAlgorithm: algorithm, key: secKey)
-                    }
-                case let publicKey as RSAPublicKey:
-                    if let secKey = try? publicKey.converted(to: SecKey.self) {
-                        return Verifier(verifyingAlgorithm: algorithm, key: secKey)
-                    }
-                case let symmetricKey as SymmetricKey:
-                    if let data = try? symmetricKey.converted(to: Data.self) {
-                        return Verifier(verifyingAlgorithm: algorithm, key: data)
-                    }
-                default:
-                    throw LogtoErrors.Verification.unsupportedJwkType
-                }
-                return nil
-            }
-
-        guard verifiers.contains(where: {
-            (try? jws.validate(using: $0)) != nil ? true : false
-        }) else {
-            throw LogtoErrors.Verification.noSigningKeyMatched
-        }
+        try verifyJws(jws, jwks: jwks)
 
         // Claims verification
         let claims = try decodeIdToken(idToken)

--- a/Sources/Logto/LogtoUtilities+IdToken.swift
+++ b/Sources/Logto/LogtoUtilities+IdToken.swift
@@ -1,0 +1,103 @@
+//
+//  LogtoUtilities+IdToken.swift
+//  
+//
+//  Created by Gao Sun on 2022/1/17.
+//
+
+import Foundation
+import JOSESwift
+
+extension LogtoUtilities {
+    private static let idTokenTolerance: UInt64 = 60
+
+    /// Decode ID Token claims WITHOUT validation.
+    /// - Parameter token: The JWT to decode
+    /// - Returns: A set of ID Token claims
+    static func decodeIdToken(_ idToken: String) throws -> IdTokenClaims {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let segments = idToken.split(separator: ".")
+
+        guard let payload = segments[safe: 1] else {
+            throw LogtoErrors.Decoding.noPayloadFound
+        }
+
+        guard let decoded = String.fromUrlSafeBase64(string: String(payload)) else {
+            throw LogtoErrors.Decoding.invalidUrlSafeBase64Encoding
+        }
+
+        return try decoder.decode(IdTokenClaims.self, from: Data(decoded.utf8))
+    }
+
+    /// Verify the give ID Token:
+    /// * One of the JWKs matches the token.
+    /// * Issuer matches token payload `iss`.
+    /// * Client ID matches token payload `aud`.
+    /// * The token is not expired.
+    /// * The token is issued in +/- 1min.
+    static func verifyIdToken(
+        _ idToken: String,
+        issuer: String,
+        clientId: String,
+        jwks: JWKSet,
+        forTimeInterval: TimeInterval = Date().timeIntervalSince1970
+    ) throws {
+        if jwks.keys.isEmpty {
+            throw LogtoErrors.Verification.missingJwk
+        }
+
+        // Public key verification
+        let jws = try JWS(compactSerialization: idToken)
+        
+        guard let algorithm = jws.header.algorithm else {
+            throw LogtoErrors.Verification.jwtMissingAlgorithmInHeader
+        }
+        
+        let verifiers: [Verifier] = try jwks
+            .keys
+            .compactMap({
+                // [RFC-7518](https://tools.ietf.org/html/rfc7518#section-7.4)
+                switch $0 {
+                case let publicKey as ECPublicKey:
+                    if let secKey = try? publicKey.converted(to: SecKey.self) {
+                        return Verifier(verifyingAlgorithm: algorithm, key: secKey)
+                    }
+                case let publicKey as RSAPublicKey:
+                    if let secKey = try? publicKey.converted(to: SecKey.self) {
+                        return Verifier(verifyingAlgorithm: algorithm, key: secKey)
+                    }
+                case let symmetricKey as SymmetricKey:
+                    if let data = try? symmetricKey.converted(to: Data.self) {
+                        return Verifier(verifyingAlgorithm: algorithm, key: data)
+                    }
+                default:
+                    throw LogtoErrors.Verification.unsupportedJwkType
+                }
+                return nil
+            })
+        
+        
+        guard verifiers.contains(where: {
+            (try? jws.validate(using: $0)) != nil ? true : false
+        }) else {
+            throw LogtoErrors.Verification.noSigningKeyMatched
+        }
+
+        // Claims verification
+        let claims = try decodeIdToken(idToken)
+        guard claims.iss == issuer else {
+            throw LogtoErrors.Verification.jwtValueMismatched(field: .issuer)
+        }
+        guard claims.aud == clientId else {
+            throw LogtoErrors.Verification.jwtValueMismatched(field: .audience)
+        }
+        guard claims.exp > Int64(forTimeInterval) else {
+            throw LogtoErrors.Verification.jwtExpired
+        }
+        guard abs(claims.iat - Int64(forTimeInterval)) <= idTokenTolerance else {
+            throw LogtoErrors.Verification.jwtIssuedTimeIncorrect
+        }
+    }
+}

--- a/Sources/Logto/LogtoUtilities+VerifyJws.swift
+++ b/Sources/Logto/LogtoUtilities+VerifyJws.swift
@@ -1,6 +1,6 @@
 //
 //  LogtoUtilities+VerifyJws.swift
-//  
+//
 //
 //  Created by Gao Sun on 2022/1/18.
 //

--- a/Sources/Logto/LogtoUtilities+VerifyJws.swift
+++ b/Sources/Logto/LogtoUtilities+VerifyJws.swift
@@ -1,0 +1,53 @@
+//
+//  LogtoUtilities+VerifyJws.swift
+//  
+//
+//  Created by Gao Sun on 2022/1/18.
+//
+
+import Foundation
+import JOSESwift
+
+extension LogtoUtilities {
+    static func verifyJws(
+        _ jws: JWS,
+        jwks: JWKSet
+    ) throws {
+        if jwks.keys.isEmpty {
+            throw LogtoErrors.Verification.missingJwk
+        }
+
+        guard let algorithm = jws.header.algorithm else {
+            throw LogtoErrors.Verification.jwtMissingAlgorithmInHeader
+        }
+
+        let verifiers: [Verifier] = try jwks
+            .keys
+            .compactMap {
+                // [RFC-7518](https://tools.ietf.org/html/rfc7518#section-7.4)
+                switch $0 {
+                case let publicKey as ECPublicKey:
+                    if let secKey = try? publicKey.converted(to: SecKey.self) {
+                        return Verifier(verifyingAlgorithm: algorithm, key: secKey)
+                    }
+                case let publicKey as RSAPublicKey:
+                    if let secKey = try? publicKey.converted(to: SecKey.self) {
+                        return Verifier(verifyingAlgorithm: algorithm, key: secKey)
+                    }
+                case let symmetricKey as SymmetricKey:
+                    if let data = try? symmetricKey.converted(to: Data.self) {
+                        return Verifier(verifyingAlgorithm: algorithm, key: data)
+                    }
+                default:
+                    throw LogtoErrors.Verification.unsupportedJwkType
+                }
+                return nil
+            }
+
+        guard verifiers.contains(where: {
+            (try? jws.validate(using: $0)) != nil ? true : false
+        }) else {
+            throw LogtoErrors.Verification.noSigningKeyMatched
+        }
+    }
+}

--- a/Sources/Logto/LogtoUtilities.swift
+++ b/Sources/Logto/LogtoUtilities.swift
@@ -10,8 +10,6 @@ import Foundation
 import JOSESwift
 
 public enum LogtoUtilities {
-    private static let idTokenTolerance: UInt64 = 60
-
     static func generateState() -> String {
         Data.randomArray(length: 64).toUrlSafeBase64String()
     }
@@ -27,70 +25,5 @@ public enum LogtoUtilities {
             _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
         }
         return Data(hash).toUrlSafeBase64String()
-    }
-
-    /// Decode ID Token claims WITHOUT validation.
-    /// - Parameter token: The JWT to decode
-    /// - Returns: A set of ID Token claims
-    static func decodeIdToken(_ idToken: String) throws -> IdTokenClaims {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-
-        let segments = idToken.split(separator: ".")
-
-        guard let payload = segments[safe: 1] else {
-            throw LogtoErrors.Decoding.noPayloadFound
-        }
-
-        guard let decoded = String.fromUrlSafeBase64(string: String(payload)) else {
-            throw LogtoErrors.Decoding.invalidUrlSafeBase64Encoding
-        }
-
-        return try decoder.decode(IdTokenClaims.self, from: Data(decoded.utf8))
-    }
-
-    /// Verify the give ID Token:
-    /// * One of the JWKs matches the token.
-    /// * Issuer matches token payload `iss`.
-    /// * Client ID matches token payload `aud`.
-    /// * The token is not expired.
-    /// * The token is issued in +/- 1min.
-    static func verifyIdToken(
-        _ idToken: String,
-        issuer: String,
-        clientId: String,
-        publicKeys: [RSAPublicKey],
-        forTimeInterval: TimeInterval = Date().timeIntervalSince1970
-    ) throws {
-        if publicKeys.isEmpty {
-            throw LogtoErrors.Verification.missingJwk
-        }
-
-        // Public key verification
-        let jws = try JWS(compactSerialization: idToken)
-        guard publicKeys
-            .compactMap({ try? $0.converted(to: SecKey.self) })
-            .compactMap({ Verifier(verifyingAlgorithm: .RS256, key: $0) })
-            .contains(where: {
-                (try? jws.validate(using: $0)) != nil ? true : false
-            })
-        else {
-            throw LogtoErrors.Verification.noPublicKeyMatched
-        }
-
-        // Claims verification
-        let claims = try decodeIdToken(idToken)
-        guard claims.iss == issuer else {
-            throw LogtoErrors.Verification.valueMismatched(field: .issuer)
-        }
-        guard claims.aud == clientId else {
-            throw LogtoErrors.Verification.valueMismatched(field: .audience)
-        }
-        guard claims.exp > Int64(forTimeInterval) else {
-            throw LogtoErrors.Verification.tokenExpired
-        }
-        guard abs(claims.iat - Int64(forTimeInterval)) <= idTokenTolerance else {
-            throw LogtoErrors.Verification.issuedTimeIncorrect
-        }
     }
 }

--- a/Sources/Logto/Types/IdTokenClaims.swift
+++ b/Sources/Logto/Types/IdTokenClaims.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct IdTokenClaims: Codable, Equatable {
     let sub: String
-    let atHash: String
+    let atHash: String?
     let aud: String
     let exp: Int64
     let iat: Int64

--- a/Sources/Logto/Types/LogtoErrors.swift
+++ b/Sources/Logto/Types/LogtoErrors.swift
@@ -15,9 +15,11 @@ public enum LogtoErrors {
 
     enum Verification: LocalizedError, Equatable {
         case missingJwk
-        case noPublicKeyMatched
-        case tokenExpired
-        case issuedTimeIncorrect
-        case valueMismatched(field: JwtField)
+        case unsupportedJwkType
+        case noSigningKeyMatched
+        case jwtMissingAlgorithmInHeader
+        case jwtExpired
+        case jwtIssuedTimeIncorrect
+        case jwtValueMismatched(field: JwtField)
     }
 }

--- a/Tests/LogtoTests/LogtoUtilitiesTests.swift
+++ b/Tests/LogtoTests/LogtoUtilitiesTests.swift
@@ -38,7 +38,8 @@ final class LogtoUtilitiesTests: XCTestCase {
         }
     }
 
-    func testVerifyIdToken() throws {
+    // MARK: Verify ID Token
+    func testVerifyIdTokenFailure() throws {
         let idToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkNza2w2SDRGR3NpLXE0QkVPT1BQOWJlbHNoRGFHZjd3RXViVU5KQllwQmsifQ.eyJzdWIiOiJ3anNadVc4VWpQd2ciLCJhdF9oYXNoIjoibkZOZGdOSWcwWmw0ZWxaTEhMVVpHZyIsImF1ZCI6ImZvbyIsImV4cCI6MTY0MTgxNTYxNywiaWF0IjoxNjQxODEyMDE3LCJpc3MiOiJodHRwczovL2xvZ3RvLmRldi9vaWRjIn0.SCAFRIRWq_iSVbbb3yO3_vvin8XUVWeFIgnsHumSdSBG8qeF9LuO-Hm4xjrTN-XREsifAfGHMrmRC23_QAkwtK8u36m-rlvBnJjq9SdqlQJAyFhCez2Uojzn97CFlwv_n8ucSyy6ToeBrbR1DqvUWdo8lrCer7WHQ3OJRe2U3pAAU9_zqMU6sntP2GshNYnA3IKylhRNFQlP91HT80ROPhgll6GCieTLlCiIeb6Q3KigBDTQ1vJYhK-NaHNP646MQeheUofhFsEZGZFS0OxNPm1FDCsxU2Nwvts7KjxjYM5wb2D5ELB1tFmes7XNWk12bNyN0dEGTugH98CtC_kIA67rZU5q9eUZRuWHPRjraWkdTemNWtW5MvBaVpAMYNJn0Fk5EKSsco_MNvZCszoKvViGo06f1YUex_jkGsOTcttdIbR-780ulWCR0txmg2gu21RRN7oMF4aTs-W7cEKOYuyRX85XTWo_Lu3BugI8kKbSwUsmO8oYPjdpipjcTf-8KJLNOkBefiWDNzM0VoysAlKYUx9aMOSD4gc7h0di7KVZFlEQ7JByn1_gyi8yHrRrHCkzLCe73gBGruijhADoISC6Uq3WmdkQvdYRpRMv0Fz9Wj6vjRhvr1nAu4ZHhsfohCIHVVMKHxXmgfjNKjBTcaRWxit39MK_-sk2Fr52F2w"
         let jwk = try RSAPublicKey(data: Data("""
             {"kty":"RSA","use":"sig","kid":"Cskl6H4FGsi-q4BEOOPP9belshDaGf7wEubUNJBYpBk","e":"AQAB","n":"pB5nO7qovnRQrSQoVmdh0g6TGtMMjc1eS0rexzcuVIgtD-7-84DHt9FaiS8UVr2Tjdp_U4Jr-mJJNbYhxae2FjNkpWf_ETND8hEYTSCZTJCkX0asnzb-xZgt2_xNiOAUzmXEaSHO215Y-WYL2LydLjoMrK70FfoFC4jnsgnnKlf1fQW2llCpG-b19w-aHU5m8fPOWKz5n27jEYNbEqHK-wsGavt7eyhVfEVPNbVl5j_n8o-VfnQT-LyO4Fg6U0XwHz1yXrT7NUMO_qdfwv1QbM0EPyWkxLoSColRZVibPmMpkc9RcOJ2crP5u602W8UOYvbtcBCaXVbzp5iriBAVxRq3tsrnTpHr-1FV5jtwU1aLMucIkOM3iJGSLoLizgwEIAnmLh1u_-lxFeSEWDX3RIE3kZOWdZoRBKcxCYPV4X7Mkca8UNW42FTeUG8f9bq43_FgZvWnnFBYpzTuHTnLlkw1a3GmjRy02_tqhV7xp5rM65Jc8HZEW81L3JKLp87ySqjKWfBkmI0ebzEPZVwV69ggI6eBVzGK1nViHsBWgDAomBGPVUqfZmACIcdy7hOp-40mDa6RscqBFtpd3RPb6lGyf2yDCH-4AY6ZRQUX10TdtW2NQon8-SBNgye4x5ZiUS7EXFxvIaTEZ_MZryS3yo5_xWtYAZLCJrDqEZLY2mE"}
@@ -46,27 +47,50 @@ final class LogtoUtilitiesTests: XCTestCase {
         let jwk2 = try RSAPublicKey(data: Data("""
             {"kty":"RSA","use":"sig","kid":"Cskl6H4FGsi-q4BEOOPP9belshDaGf7wEubUNJBYpBk","e":"AQAB","n":"1B5nO7qovnRQrSQoVmdh0g6TGtMMjc1eS0rexzcuVIgtD-7-84DHt9FaiS8UVr2Tjdp_U4Jr-mJJNbYhxae2FjNkpWf_ETND8hEYTSCZTJCkX0asnzb-xZgt2_xNiOAUzmXEaSHO215Y-WYL2LydLjoMrK70FfoFC4jnsgnnKlf1fQW2llCpG-b19w-aHU5m8fPOWKz5n27jEYNbEqHK-wsGavt7eyhVfEVPNbVl5j_n8o-VfnQT-LyO4Fg6U0XwHz1yXrT7NUMO_qdfwv1QbM0EPyWkxLoSColRZVibPmMpkc9RcOJ2crP5u602W8UOYvbtcBCaXVbzp5iriBAVxRq3tsrnTpHr-1FV5jtwU1aLMucIkOM3iJGSLoLizgwEIAnmLh1u_-lxFeSEWDX3RIE3kZOWdZoRBKcxCYPV4X7Mkca8UNW42FTeUG8f9bq43_FgZvWnnFBYpzTuHTnLlkw1a3GmjRy02_tqhV7xp5rM65Jc8HZEW81L3JKLp87ySqjKWfBkmI0ebzEPZVwV69ggI6eBVzGK1nViHsBWgDAomBGPVUqfZmACIcdy7hOp-40mDa6RscqBFtpd3RPb6lGyf2yDCH-4AY6ZRQUX10TdtW2NQon8-SBNgye4x5ZiUS7EXFxvIaTEZ_MZryS3yo5_xWtYAZLCJrDqEZLY2mE"}
         """.utf8))
+        let jwks = JWKSet(keys: [jwk2, jwk])
+        let jwks2 = JWKSet(keys: [jwk2])
         let issuer = "https://logto.dev/oidc"
         let clientId = "foo"
 
-        XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: "foo", clientId: "bar", publicKeys: [])) {
+        XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: "foo", clientId: "bar", jwks: JWKSet(keys: []))) {
             XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.missingJwk)
         }
-        XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: "foo", clientId: "bar", publicKeys: [jwk2])) {
-            XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.noPublicKeyMatched)
+        XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: "foo", clientId: "bar", jwks: jwks2)) {
+            XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.noSigningKeyMatched)
         }
-        XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: "foo", clientId: "bar", publicKeys: [jwk])) {
-            XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.valueMismatched(field: .issuer))
+        XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: "foo", clientId: "bar", jwks: jwks)) {
+            XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.jwtValueMismatched(field: .issuer))
         }
-        XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: issuer, clientId: "bar", publicKeys: [jwk])) {
-            XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.valueMismatched(field: .audience))
+        XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: issuer, clientId: "bar", jwks: jwks)) {
+            XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.jwtValueMismatched(field: .audience))
         }
-        XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: issuer, clientId: clientId, publicKeys: [jwk], forTimeInterval: 1_641_815_618)) {
-            XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.tokenExpired)
+        XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: issuer, clientId: clientId, jwks: jwks, forTimeInterval: 1_641_815_618)) {
+            XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.jwtExpired)
         }
-        XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: issuer, clientId: clientId, publicKeys: [jwk], forTimeInterval: 0)) {
-            XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.issuedTimeIncorrect)
+        XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: issuer, clientId: clientId, jwks: jwks, forTimeInterval: 0)) {
+            XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.jwtIssuedTimeIncorrect)
         }
-        XCTAssertNoThrow(try LogtoUtilities.verifyIdToken(idToken, issuer: issuer, clientId: clientId, publicKeys: [jwk], forTimeInterval: 1_641_812_017))
+    }
+    
+    func testVerifyIdTokenRSA() throws {
+        let idToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkNza2w2SDRGR3NpLXE0QkVPT1BQOWJlbHNoRGFHZjd3RXViVU5KQllwQmsifQ.eyJzdWIiOiJ3anNadVc4VWpQd2ciLCJhdF9oYXNoIjoibkZOZGdOSWcwWmw0ZWxaTEhMVVpHZyIsImF1ZCI6ImZvbyIsImV4cCI6MTY0MTgxNTYxNywiaWF0IjoxNjQxODEyMDE3LCJpc3MiOiJodHRwczovL2xvZ3RvLmRldi9vaWRjIn0.SCAFRIRWq_iSVbbb3yO3_vvin8XUVWeFIgnsHumSdSBG8qeF9LuO-Hm4xjrTN-XREsifAfGHMrmRC23_QAkwtK8u36m-rlvBnJjq9SdqlQJAyFhCez2Uojzn97CFlwv_n8ucSyy6ToeBrbR1DqvUWdo8lrCer7WHQ3OJRe2U3pAAU9_zqMU6sntP2GshNYnA3IKylhRNFQlP91HT80ROPhgll6GCieTLlCiIeb6Q3KigBDTQ1vJYhK-NaHNP646MQeheUofhFsEZGZFS0OxNPm1FDCsxU2Nwvts7KjxjYM5wb2D5ELB1tFmes7XNWk12bNyN0dEGTugH98CtC_kIA67rZU5q9eUZRuWHPRjraWkdTemNWtW5MvBaVpAMYNJn0Fk5EKSsco_MNvZCszoKvViGo06f1YUex_jkGsOTcttdIbR-780ulWCR0txmg2gu21RRN7oMF4aTs-W7cEKOYuyRX85XTWo_Lu3BugI8kKbSwUsmO8oYPjdpipjcTf-8KJLNOkBefiWDNzM0VoysAlKYUx9aMOSD4gc7h0di7KVZFlEQ7JByn1_gyi8yHrRrHCkzLCe73gBGruijhADoISC6Uq3WmdkQvdYRpRMv0Fz9Wj6vjRhvr1nAu4ZHhsfohCIHVVMKHxXmgfjNKjBTcaRWxit39MK_-sk2Fr52F2w"
+        let jwk = try RSAPublicKey(data: Data("""
+            {"kty":"RSA","use":"sig","kid":"Cskl6H4FGsi-q4BEOOPP9belshDaGf7wEubUNJBYpBk","e":"AQAB","n":"pB5nO7qovnRQrSQoVmdh0g6TGtMMjc1eS0rexzcuVIgtD-7-84DHt9FaiS8UVr2Tjdp_U4Jr-mJJNbYhxae2FjNkpWf_ETND8hEYTSCZTJCkX0asnzb-xZgt2_xNiOAUzmXEaSHO215Y-WYL2LydLjoMrK70FfoFC4jnsgnnKlf1fQW2llCpG-b19w-aHU5m8fPOWKz5n27jEYNbEqHK-wsGavt7eyhVfEVPNbVl5j_n8o-VfnQT-LyO4Fg6U0XwHz1yXrT7NUMO_qdfwv1QbM0EPyWkxLoSColRZVibPmMpkc9RcOJ2crP5u602W8UOYvbtcBCaXVbzp5iriBAVxRq3tsrnTpHr-1FV5jtwU1aLMucIkOM3iJGSLoLizgwEIAnmLh1u_-lxFeSEWDX3RIE3kZOWdZoRBKcxCYPV4X7Mkca8UNW42FTeUG8f9bq43_FgZvWnnFBYpzTuHTnLlkw1a3GmjRy02_tqhV7xp5rM65Jc8HZEW81L3JKLp87ySqjKWfBkmI0ebzEPZVwV69ggI6eBVzGK1nViHsBWgDAomBGPVUqfZmACIcdy7hOp-40mDa6RscqBFtpd3RPb6lGyf2yDCH-4AY6ZRQUX10TdtW2NQon8-SBNgye4x5ZiUS7EXFxvIaTEZ_MZryS3yo5_xWtYAZLCJrDqEZLY2mE"}
+        """.utf8))
+        let jwks = JWKSet(keys: [jwk])
+        let issuer = "https://logto.dev/oidc"
+        let clientId = "foo"
+        XCTAssertNoThrow(try LogtoUtilities.verifyIdToken(idToken, issuer: issuer, clientId: clientId, jwks: jwks, forTimeInterval: 1_641_812_017))
+    }
+    
+    func testVerifyIdTokenEC() throws {
+        let idToken = "eyJhbGciOiJFUzUxMiJ9.eyJ1cm46ZXhhbXBsZTpjbGFpbSI6dHJ1ZSwiaWF0IjoxNjQyNDA5NjQ4LCJpc3MiOiJodHRwczovL2xvZ3RvLmRldi9vaWRjIiwic3ViIjoiZm9vIiwiYXVkIjoiMTIzIiwiZXhwIjoxNjQyNDE2ODQ4fQ.ABQro2j_TvBHv9rUaOGBbLrWiW0XgpWTGhEus95uvnFkB2AqPFRNG_mF4P5Q3VPMVke-b6KkVdZ9En0T1BNJ7vmHAQhSVamZSpj6A_fKLhR7cghYsl4yX0vMPpiC7fdluskMLj_68wOaQ3Gay48MqQqPevw_6VKKZ7FMdS8UrwDgCqmX"
+        let jwk = try ECPublicKey(data: Data("""
+            {"kty":"EC","x":"AOFMpV0kE_gJqYs0Apah4NWYz8UMV7xkbqeIC4cP4d_HSvo4p3n8EhxJf-7wBxF4yOX5ctwH1DmK5U40-lqQF3gP","y":"AS9fnFxFydqBbKjnSO_YOX0LWgdxA4N0Td-xEgsPPhgc_PkkvoE2307IlbRh6cvFcWm7hO_dnlRnyC420tEDEtTy","crv":"P-521"}
+        """.utf8))
+        let jwks = JWKSet(keys: [jwk])
+        let issuer = "https://logto.dev/oidc"
+        let clientId = "123"
+        XCTAssertNoThrow(try LogtoUtilities.verifyIdToken(idToken, issuer: issuer, clientId: clientId, jwks: jwks, forTimeInterval: 1642409648))
     }
 }

--- a/Tests/LogtoTests/LogtoUtilitiesTests.swift
+++ b/Tests/LogtoTests/LogtoUtilitiesTests.swift
@@ -39,6 +39,7 @@ final class LogtoUtilitiesTests: XCTestCase {
     }
 
     // MARK: Verify ID Token
+
     func testVerifyIdTokenFailure() throws {
         let idToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkNza2w2SDRGR3NpLXE0QkVPT1BQOWJlbHNoRGFHZjd3RXViVU5KQllwQmsifQ.eyJzdWIiOiJ3anNadVc4VWpQd2ciLCJhdF9oYXNoIjoibkZOZGdOSWcwWmw0ZWxaTEhMVVpHZyIsImF1ZCI6ImZvbyIsImV4cCI6MTY0MTgxNTYxNywiaWF0IjoxNjQxODEyMDE3LCJpc3MiOiJodHRwczovL2xvZ3RvLmRldi9vaWRjIn0.SCAFRIRWq_iSVbbb3yO3_vvin8XUVWeFIgnsHumSdSBG8qeF9LuO-Hm4xjrTN-XREsifAfGHMrmRC23_QAkwtK8u36m-rlvBnJjq9SdqlQJAyFhCez2Uojzn97CFlwv_n8ucSyy6ToeBrbR1DqvUWdo8lrCer7WHQ3OJRe2U3pAAU9_zqMU6sntP2GshNYnA3IKylhRNFQlP91HT80ROPhgll6GCieTLlCiIeb6Q3KigBDTQ1vJYhK-NaHNP646MQeheUofhFsEZGZFS0OxNPm1FDCsxU2Nwvts7KjxjYM5wb2D5ELB1tFmes7XNWk12bNyN0dEGTugH98CtC_kIA67rZU5q9eUZRuWHPRjraWkdTemNWtW5MvBaVpAMYNJn0Fk5EKSsco_MNvZCszoKvViGo06f1YUex_jkGsOTcttdIbR-780ulWCR0txmg2gu21RRN7oMF4aTs-W7cEKOYuyRX85XTWo_Lu3BugI8kKbSwUsmO8oYPjdpipjcTf-8KJLNOkBefiWDNzM0VoysAlKYUx9aMOSD4gc7h0di7KVZFlEQ7JByn1_gyi8yHrRrHCkzLCe73gBGruijhADoISC6Uq3WmdkQvdYRpRMv0Fz9Wj6vjRhvr1nAu4ZHhsfohCIHVVMKHxXmgfjNKjBTcaRWxit39MK_-sk2Fr52F2w"
         let jwk = try RSAPublicKey(data: Data("""
@@ -71,7 +72,7 @@ final class LogtoUtilitiesTests: XCTestCase {
             XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.jwtIssuedTimeIncorrect)
         }
     }
-    
+
     func testVerifyIdTokenRSA() throws {
         let idToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkNza2w2SDRGR3NpLXE0QkVPT1BQOWJlbHNoRGFHZjd3RXViVU5KQllwQmsifQ.eyJzdWIiOiJ3anNadVc4VWpQd2ciLCJhdF9oYXNoIjoibkZOZGdOSWcwWmw0ZWxaTEhMVVpHZyIsImF1ZCI6ImZvbyIsImV4cCI6MTY0MTgxNTYxNywiaWF0IjoxNjQxODEyMDE3LCJpc3MiOiJodHRwczovL2xvZ3RvLmRldi9vaWRjIn0.SCAFRIRWq_iSVbbb3yO3_vvin8XUVWeFIgnsHumSdSBG8qeF9LuO-Hm4xjrTN-XREsifAfGHMrmRC23_QAkwtK8u36m-rlvBnJjq9SdqlQJAyFhCez2Uojzn97CFlwv_n8ucSyy6ToeBrbR1DqvUWdo8lrCer7WHQ3OJRe2U3pAAU9_zqMU6sntP2GshNYnA3IKylhRNFQlP91HT80ROPhgll6GCieTLlCiIeb6Q3KigBDTQ1vJYhK-NaHNP646MQeheUofhFsEZGZFS0OxNPm1FDCsxU2Nwvts7KjxjYM5wb2D5ELB1tFmes7XNWk12bNyN0dEGTugH98CtC_kIA67rZU5q9eUZRuWHPRjraWkdTemNWtW5MvBaVpAMYNJn0Fk5EKSsco_MNvZCszoKvViGo06f1YUex_jkGsOTcttdIbR-780ulWCR0txmg2gu21RRN7oMF4aTs-W7cEKOYuyRX85XTWo_Lu3BugI8kKbSwUsmO8oYPjdpipjcTf-8KJLNOkBefiWDNzM0VoysAlKYUx9aMOSD4gc7h0di7KVZFlEQ7JByn1_gyi8yHrRrHCkzLCe73gBGruijhADoISC6Uq3WmdkQvdYRpRMv0Fz9Wj6vjRhvr1nAu4ZHhsfohCIHVVMKHxXmgfjNKjBTcaRWxit39MK_-sk2Fr52F2w"
         let jwk = try RSAPublicKey(data: Data("""
@@ -82,7 +83,7 @@ final class LogtoUtilitiesTests: XCTestCase {
         let clientId = "foo"
         XCTAssertNoThrow(try LogtoUtilities.verifyIdToken(idToken, issuer: issuer, clientId: clientId, jwks: jwks, forTimeInterval: 1_641_812_017))
     }
-    
+
     func testVerifyIdTokenEC() throws {
         let idToken = "eyJhbGciOiJFUzUxMiJ9.eyJ1cm46ZXhhbXBsZTpjbGFpbSI6dHJ1ZSwiaWF0IjoxNjQyNDA5NjQ4LCJpc3MiOiJodHRwczovL2xvZ3RvLmRldi9vaWRjIiwic3ViIjoiZm9vIiwiYXVkIjoiMTIzIiwiZXhwIjoxNjQyNDE2ODQ4fQ.ABQro2j_TvBHv9rUaOGBbLrWiW0XgpWTGhEus95uvnFkB2AqPFRNG_mF4P5Q3VPMVke-b6KkVdZ9En0T1BNJ7vmHAQhSVamZSpj6A_fKLhR7cghYsl4yX0vMPpiC7fdluskMLj_68wOaQ3Gay48MqQqPevw_6VKKZ7FMdS8UrwDgCqmX"
         let jwk = try ECPublicKey(data: Data("""
@@ -91,6 +92,6 @@ final class LogtoUtilitiesTests: XCTestCase {
         let jwks = JWKSet(keys: [jwk])
         let issuer = "https://logto.dev/oidc"
         let clientId = "123"
-        XCTAssertNoThrow(try LogtoUtilities.verifyIdToken(idToken, issuer: issuer, clientId: clientId, jwks: jwks, forTimeInterval: 1642409648))
+        XCTAssertNoThrow(try LogtoUtilities.verifyIdToken(idToken, issuer: issuer, clientId: clientId, jwks: jwks, forTimeInterval: 1_642_409_648))
     }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
- update `verifyIdToken()` to match SDK convention
- support all JWK types in [RFC-7518](https://tools.ietf.org/html/rfc7518#section-7.4)
- test `ES512` JWT

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

UT

<!-- MANDATORY -->
## Reviwers
<!-- Update if needed. -->

@logto-io/eng
