### PR TITLE
refactor: use `Int64` over the repo

### DIFF
--- a/Sources/Logto/Core/LogtoCore+Fetch.swift
+++ b/Sources/Logto/Core/LogtoCore+Fetch.swift
@@ -41,7 +41,7 @@ extension LogtoCore {
         let refreshToken: String
         let idToken: String
         let scope: String
-        let expiresIn: UInt64
+        let expiresIn: Int64
     }
 
     /// Fetch token by `authorization_code`.
@@ -79,7 +79,7 @@ extension LogtoCore {
         let refreshToken: String
         let idToken: String?
         let scope: String
-        let expiresIn: UInt64
+        let expiresIn: Int64
     }
 
     /// Fetch token by `refresh_token`.

--- a/Sources/Logto/Utilities/LogtoUtilities+IdToken.swift
+++ b/Sources/Logto/Utilities/LogtoUtilities+IdToken.swift
@@ -9,7 +9,7 @@ import Foundation
 import JOSESwift
 
 extension LogtoUtilities {
-    private static let idTokenTolerance: UInt64 = 60
+    private static let idTokenTolerance: Int64 = 60
 
     /// Decode ID Token claims WITHOUT validation.
     /// - Parameter token: The JWT to decode


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
align timestamp type

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Reviwers
<!-- Update if needed. -->

@logto-io/eng
