### PR TITLE
feat: `withReservedScopes()`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,5 +37,9 @@ let package = Package(
             name: "LogtoClient",
             dependencies: ["Logto"]
         ),
+        .testTarget(
+            name: "LogtoClientTests",
+            dependencies: ["LogtoClient"]
+        ),
     ]
 )

--- a/Sources/Logto/Core/LogtoCore+Generate.swift
+++ b/Sources/Logto/Core/LogtoCore+Generate.swift
@@ -38,7 +38,7 @@ extension LogtoCore {
             URLQueryItem(name: "code_challenge", value: codeChallenge),
             URLQueryItem(name: "code_challenge_method", value: LogtoCore.codeChallengeMethod),
             URLQueryItem(name: "state", value: state),
-            URLQueryItem(name: "scope", value: (scope?.inArray ?? []).joined(separator: " ")),
+            URLQueryItem(name: "scope", value: LogtoUtilities.withReservedScopes(scope).joined(separator: " ")),
             URLQueryItem(name: "response_type", value: LogtoCore.responseType),
             URLQueryItem(name: "prompt", value: LogtoCore.prompt),
         ]

--- a/Sources/Logto/Utilities/LogtoUtilities.swift
+++ b/Sources/Logto/Utilities/LogtoUtilities.swift
@@ -10,11 +10,17 @@ import Foundation
 import JOSESwift
 
 public enum LogtoUtilities {
-    static func generateState() -> String {
+    static let reservedScopes = ["openid", "offline_access"]
+    
+    public static func withReservedScopes(_ scopes: ValueOrArray<String>?) -> [String] {
+        Array(Set((scopes?.inArray ?? []) + reservedScopes)).sorted()
+    }
+    
+    public static func generateState() -> String {
         Data.randomArray(length: 64).toUrlSafeBase64String()
     }
 
-    static func generateCodeVerifier() -> String {
+    public static func generateCodeVerifier() -> String {
         Data.randomArray(length: 64).toUrlSafeBase64String()
     }
 

--- a/Sources/Logto/Utilities/LogtoUtilities.swift
+++ b/Sources/Logto/Utilities/LogtoUtilities.swift
@@ -11,11 +11,11 @@ import JOSESwift
 
 public enum LogtoUtilities {
     static let reservedScopes = ["openid", "offline_access"]
-    
+
     public static func withReservedScopes(_ scopes: ValueOrArray<String>?) -> [String] {
         Array(Set((scopes?.inArray ?? []) + reservedScopes)).sorted()
     }
-    
+
     public static func generateState() -> String {
         Data.randomArray(length: 64).toUrlSafeBase64String()
     }

--- a/Sources/LogtoClient/Types/LogtoConfig.swift
+++ b/Sources/LogtoClient/Types/LogtoConfig.swift
@@ -9,14 +9,15 @@ import Foundation
 import Logto
 
 public struct LogtoConfig {
+    private let _scope: ValueOrArray<String>?
+
     let endpoint: String
     let clientId: String
-    let scope: ValueOrArray<String>?
     let resource: ValueOrArray<String>?
     let usingPersistStorage: Bool
 
-    var computedScopes: [String] {
-        LogtoUtilities.withReservedScopes(scope)
+    var scope: [String] {
+        LogtoUtilities.withReservedScopes(_scope)
     }
 
     // Have to do this in Swift
@@ -29,7 +30,7 @@ public struct LogtoConfig {
     ) {
         self.endpoint = endpoint
         self.clientId = clientId
-        self.scope = scope
+        _scope = scope
         self.resource = resource
         self.usingPersistStorage = usingPersistStorage
     }

--- a/Sources/LogtoClient/Types/LogtoConfig.swift
+++ b/Sources/LogtoClient/Types/LogtoConfig.swift
@@ -14,13 +14,19 @@ public struct LogtoConfig {
     let scope: ValueOrArray<String>?
     let resource: ValueOrArray<String>?
     let usingPersistStorage: Bool
-    
+
     var computedScopes: [String] {
         LogtoUtilities.withReservedScopes(scope)
     }
-    
+
     // Have to do this in Swift
-    init(endpoint: String, clientId: String, scope: ValueOrArray<String>? = nil, resource: ValueOrArray<String>? = nil, usingPersistStorage: Bool = false) {
+    init(
+        endpoint: String,
+        clientId: String,
+        scope: ValueOrArray<String>? = nil,
+        resource: ValueOrArray<String>? = nil,
+        usingPersistStorage: Bool = false
+    ) {
         self.endpoint = endpoint
         self.clientId = clientId
         self.scope = scope

--- a/Sources/LogtoClient/Types/LogtoConfig.swift
+++ b/Sources/LogtoClient/Types/LogtoConfig.swift
@@ -11,7 +11,20 @@ import Logto
 public struct LogtoConfig {
     let endpoint: String
     let clientId: String
-    let scope: ValueOrArray<String>? = nil
-    let resource: ValueOrArray<String>? = nil
-    let usingPersistStorage: Bool = false
+    let scope: ValueOrArray<String>?
+    let resource: ValueOrArray<String>?
+    let usingPersistStorage: Bool
+    
+    var computedScopes: [String] {
+        LogtoUtilities.withReservedScopes(scope)
+    }
+    
+    // Have to do this in Swift
+    init(endpoint: String, clientId: String, scope: ValueOrArray<String>? = nil, resource: ValueOrArray<String>? = nil, usingPersistStorage: Bool = false) {
+        self.endpoint = endpoint
+        self.clientId = clientId
+        self.scope = scope
+        self.resource = resource
+        self.usingPersistStorage = usingPersistStorage
+    }
 }

--- a/Tests/LogtoClientTests/Types/LogtoConfigTests.swift
+++ b/Tests/LogtoClientTests/Types/LogtoConfigTests.swift
@@ -4,6 +4,6 @@ import XCTest
 final class LogtoConfigTests: XCTestCase {
     func testLogtoConfig() throws {
         let config = LogtoConfig(endpoint: "foo", clientId: "bar", scope: .value("scope1"))
-        XCTAssertEqual(config.computedScopes, ["offline_access", "openid", "scope1"])
+        XCTAssertEqual(config.scope, ["offline_access", "openid", "scope1"])
     }
 }

--- a/Tests/LogtoClientTests/Types/LogtoConfigTests.swift
+++ b/Tests/LogtoClientTests/Types/LogtoConfigTests.swift
@@ -1,0 +1,9 @@
+@testable import LogtoClient
+import XCTest
+
+final class LogtoConfigTests: XCTestCase {
+    func testLogtoConfig() throws {
+        let config = LogtoConfig(endpoint: "foo", clientId: "bar", scope: .value("scope1"))
+        XCTAssertEqual(config.computedScopes, ["offline_access", "openid", "scope1"])
+    }
+}

--- a/Tests/LogtoTests/LogtoCoreTests+Generate.swift
+++ b/Tests/LogtoTests/LogtoCoreTests+Generate.swift
@@ -33,7 +33,7 @@ extension LogtoCoreTests {
         try validateBaseInformation(url: url)
         XCTAssertEqual(
             url.query,
-            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&response_type=authorization_code&prompt=consent"
+            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=authorization_code&prompt=consent"
         )
     }
 
@@ -51,7 +51,7 @@ extension LogtoCoreTests {
         try validateBaseInformation(url: url1)
         XCTAssertEqual(
             url1.query,
-            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=foo&response_type=authorization_code&prompt=consent"
+            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=foo%20offline_access%20openid&response_type=authorization_code&prompt=consent"
         )
 
         let url2 = try LogtoCore.generateSignInUri(
@@ -65,7 +65,7 @@ extension LogtoCoreTests {
         try validateBaseInformation(url: url2)
         XCTAssertEqual(
             url2.query,
-            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=foo%20bar&response_type=authorization_code&prompt=consent"
+            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=bar%20foo%20offline_access%20openid&response_type=authorization_code&prompt=consent"
         )
     }
 
@@ -83,7 +83,7 @@ extension LogtoCoreTests {
         try validateBaseInformation(url: url1)
         XCTAssertEqual(
             url1.query,
-            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&response_type=authorization_code&prompt=consent&resource=https://api.logto.dev/"
+            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=authorization_code&prompt=consent&resource=https://api.logto.dev/"
         )
 
         let url2 = try LogtoCore.generateSignInUri(
@@ -97,7 +97,7 @@ extension LogtoCoreTests {
         try validateBaseInformation(url: url2)
         XCTAssertEqual(
             url2.query,
-            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&response_type=authorization_code&prompt=consent&resource=https://api.logto.dev/&resource=bar"
+            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=authorization_code&prompt=consent&resource=https://api.logto.dev/&resource=bar"
         )
     }
 

--- a/Tests/LogtoTests/LogtoUtilitiesTests.swift
+++ b/Tests/LogtoTests/LogtoUtilitiesTests.swift
@@ -3,6 +3,12 @@ import JOSESwift
 import XCTest
 
 final class LogtoUtilitiesTests: XCTestCase {
+    func testWithReservedScopes() throws {
+        XCTAssertEqual(LogtoUtilities.withReservedScopes(nil), ["offline_access", "openid"])
+        XCTAssertEqual(LogtoUtilities.withReservedScopes(.value("foo")), ["foo", "offline_access", "openid"])
+        XCTAssertEqual(LogtoUtilities.withReservedScopes(.array(["foo", "xyz"])), ["foo", "offline_access", "openid", "xyz"])
+    }
+    
     func testGenerateState() throws {
         let state = LogtoUtilities.generateState()
         XCTAssertTrue(state.isUrlSafe)

--- a/Tests/LogtoTests/LogtoUtilitiesTests.swift
+++ b/Tests/LogtoTests/LogtoUtilitiesTests.swift
@@ -6,9 +6,12 @@ final class LogtoUtilitiesTests: XCTestCase {
     func testWithReservedScopes() throws {
         XCTAssertEqual(LogtoUtilities.withReservedScopes(nil), ["offline_access", "openid"])
         XCTAssertEqual(LogtoUtilities.withReservedScopes(.value("foo")), ["foo", "offline_access", "openid"])
-        XCTAssertEqual(LogtoUtilities.withReservedScopes(.array(["foo", "xyz"])), ["foo", "offline_access", "openid", "xyz"])
+        XCTAssertEqual(
+            LogtoUtilities.withReservedScopes(.array(["foo", "xyz"])),
+            ["foo", "offline_access", "openid", "xyz"]
+        )
     }
-    
+
     func testGenerateState() throws {
         let state = LogtoUtilities.generateState()
         XCTAssertTrue(state.isUrlSafe)


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
- implement `LogtoUtilities.withReservedScopes()` to add `["openid", "offline_access"]` and dedup scopes
- add computed prop `.scope` to `LogtoConfig`
- add a more developer-friendly init of `LogtoConfig`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT

<!-- MANDATORY -->
## Reviwers
<!-- Update if needed. -->

@logto-io/eng
