### PR TITLE
feat(iOS): `signInWithBrowser()`

### DIFF
--- a/Demos/SwiftUI Demo/SwiftUI Demo.xcodeproj/project.pbxproj
+++ b/Demos/SwiftUI Demo/SwiftUI Demo.xcodeproj/project.pbxproj
@@ -99,8 +99,8 @@
 		6C88C0A127A3D8060007B4D4 /* SwiftUI Demo */ = {
 			isa = PBXGroup;
 			children = (
-				6C88C0A227A3D8060007B4D4 /* SwiftUI_DemoApp.swift */,
 				6C88C0A427A3D8060007B4D4 /* ContentView.swift */,
+				6C88C0A227A3D8060007B4D4 /* SwiftUI_DemoApp.swift */,
 				6C88C0A627A3D8060007B4D4 /* Assets.xcassets */,
 				6C88C0A827A3D8060007B4D4 /* Preview Content */,
 			);

--- a/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
+++ b/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
@@ -9,16 +9,24 @@ import LogtoClient
 import SwiftUI
 
 struct ContentView: View {
+    let client: LogtoClient?
+
     init() {
-        guard let config = try? LogtoConfig(endpoint: "https://logto.dev", clientId: "foo") else {
+        guard let config = try? LogtoConfig(endpoint: "https://logto.dev", clientId: "z4skkM1Z8LLVSl1JCmVZO") else {
+            client = nil
             return
         }
-        _ = LogtoClient(useConfig: config)
+        client = LogtoClient(useConfig: config)
     }
 
     var body: some View {
         Text("Hello, world!")
             .padding()
+        if let client = client {
+            Button("Sign In") {
+                client.signInWithBrowser()
+            }
+        }
     }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Logto SDK",
-    platforms: [.iOS(.v13), .macOS(.v10_15), .watchOS(.v5)],
+    platforms: [.iOS(.v12), .macOS(.v10_15), .watchOS(.v5)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/Logto/Core/LogtoCore+Fetch.swift
+++ b/Sources/Logto/Core/LogtoCore+Fetch.swift
@@ -11,12 +11,12 @@ extension LogtoCore {
     // MARK: OIDC Config
 
     public struct OidcConfigResponse: Codable, Equatable {
-        let authorizationEndpoint: String
-        let tokenEndpoint: String
-        let endSessionEndpoint: String
-        let revocationEndpoint: String
-        let jwksUri: String
-        let issuer: String
+        public let authorizationEndpoint: String
+        public let tokenEndpoint: String
+        public let endSessionEndpoint: String
+        public let revocationEndpoint: String
+        public let jwksUri: String
+        public let issuer: String
     }
 
     static func fetchOidcConfig(

--- a/Sources/Logto/Core/LogtoCore+Generate.swift
+++ b/Sources/Logto/Core/LogtoCore+Generate.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-extension LogtoCore {
+public extension LogtoCore {
     private static let codeChallengeMethod = "S256"
-    private static let responseType = "authorization_code"
+    private static let responseType = "code"
     private static let prompt = "consent"
 
     static func generateSignInUri(

--- a/Sources/Logto/Utilities/LogtoUtilities.swift
+++ b/Sources/Logto/Utilities/LogtoUtilities.swift
@@ -30,7 +30,7 @@ public enum LogtoUtilities {
         Data.randomArray(length: 64).toUrlSafeBase64String()
     }
 
-    static func generateCodeChallenge(codeVerifier: String) -> String {
+    public static func generateCodeChallenge(codeVerifier: String) -> String {
         let data = Data(codeVerifier.utf8)
         var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
         data.withUnsafeBytes {

--- a/Sources/LogtoClient/LogtoClient/LogtoClient.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient.swift
@@ -9,6 +9,7 @@ import Foundation
 import Logto
 
 public class LogtoClient {
+    internal let authContext = LogtoAuthContext()
     internal let accessTokenMap: [String: AccessToken] = [:]
     internal let logtoConfig: LogtoConfig
     internal let networkSession: NetworkSession
@@ -23,7 +24,7 @@ public class LogtoClient {
         // TO-DO: LOG-1398 set up and use persist storage if needed
     }
 
-    var isAuthenticated: Bool {
+    public var isAuthenticated: Bool {
         idToken != nil
     }
 }

--- a/Sources/LogtoClient/Types/LogtoAuthContext.swift
+++ b/Sources/LogtoClient/Types/LogtoAuthContext.swift
@@ -1,0 +1,15 @@
+//
+//  LogtoAuthContext.swift
+//
+//
+//  Created by Gao Sun on 2022/1/29.
+//
+
+import AuthenticationServices
+import Foundation
+
+class LogtoAuthContext: NSObject, ASWebAuthenticationPresentationContextProviding {
+    func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        ASPresentationAnchor()
+    }
+}

--- a/Tests/LogtoTests/LogtoCoreTests+Generate.swift
+++ b/Tests/LogtoTests/LogtoCoreTests+Generate.swift
@@ -33,7 +33,7 @@ extension LogtoCoreTests {
         try validateBaseInformation(url: url)
         XCTAssertEqual(
             url.query,
-            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=authorization_code&prompt=consent"
+            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=code&prompt=consent"
         )
     }
 
@@ -51,7 +51,7 @@ extension LogtoCoreTests {
         try validateBaseInformation(url: url1)
         XCTAssertEqual(
             url1.query,
-            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=foo%20offline_access%20openid&response_type=authorization_code&prompt=consent"
+            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=foo%20offline_access%20openid&response_type=code&prompt=consent"
         )
 
         let url2 = try LogtoCore.generateSignInUri(
@@ -65,7 +65,7 @@ extension LogtoCoreTests {
         try validateBaseInformation(url: url2)
         XCTAssertEqual(
             url2.query,
-            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=bar%20foo%20offline_access%20openid&response_type=authorization_code&prompt=consent"
+            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=bar%20foo%20offline_access%20openid&response_type=code&prompt=consent"
         )
     }
 
@@ -83,7 +83,7 @@ extension LogtoCoreTests {
         try validateBaseInformation(url: url1)
         XCTAssertEqual(
             url1.query,
-            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=authorization_code&prompt=consent&resource=https://api.logto.dev/"
+            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=code&prompt=consent&resource=https://api.logto.dev/"
         )
 
         let url2 = try LogtoCore.generateSignInUri(
@@ -97,7 +97,7 @@ extension LogtoCoreTests {
         try validateBaseInformation(url: url2)
         XCTAssertEqual(
             url2.query,
-            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=authorization_code&prompt=consent&resource=https://api.logto.dev/&resource=bar"
+            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=code&prompt=consent&resource=https://api.logto.dev/&resource=bar"
         )
     }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

init iOS implementation of `signInWithBrowser()` using [Authentication Services](https://developer.apple.com/documentation/authenticationservices/authenticating_a_user_through_a_web_service)

To-dos:

- error handling
- fetch token by code
- persist storage

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
in `SwiftUI Demo` app, signed in with logto.dev and returned desired URL.

![image](https://user-images.githubusercontent.com/14722250/151659000-60f1e809-ec6b-441d-a064-73b93a9c5d76.png)

<!-- MANDATORY -->
## Reviewers
<!-- Update if needed. -->

@logto-io/eng
