### PR TITLE
feat: use keychain as persist storage

### DIFF
--- a/Demos/SwiftUI Demo/SwiftUI Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demos/SwiftUI Demo/SwiftUI Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -9,6 +9,15 @@
           "revision": "10ed3b6736def7c26eb87135466b1cb46ea7e37f",
           "version": "2.4.0"
         }
+      },
+      {
+        "package": "KeychainAccess",
+        "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess.git",
+        "state": {
+          "branch": null,
+          "revision": "84e546727d66f1adc5439debad16270d0fdd04e7",
+          "version": "4.2.2"
+        }
       }
     ]
   },

--- a/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
+++ b/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
@@ -28,8 +28,8 @@ struct ContentView: View {
         let logtoClient = LogtoClient(useConfig: config)
         client = logtoClient
         isAuthenticated = logtoClient.isAuthenticated
-        
-        if (logtoClient.isAuthenticated) {
+
+        if logtoClient.isAuthenticated {
             print("authed", logtoClient.idToken ?? "N/A")
         }
     }

--- a/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
+++ b/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
@@ -10,7 +10,7 @@ import LogtoClient
 import SwiftUI
 
 struct ContentView: View {
-    @State var isAuthenticated = false
+    @State var isAuthenticated: Bool
     @State var authError: Error?
 
     let client: LogtoClient?
@@ -22,9 +22,16 @@ struct ContentView: View {
             resources: ["https://api.logto.io"]
         ) else {
             client = nil
+            isAuthenticated = false
             return
         }
-        client = LogtoClient(useConfig: config)
+        let logtoClient = LogtoClient(useConfig: config)
+        client = logtoClient
+        isAuthenticated = logtoClient.isAuthenticated
+        
+        if (logtoClient.isAuthenticated) {
+            print("authed", logtoClient.idToken ?? "N/A")
+        }
     }
 
     var body: some View {

--- a/Package.resolved
+++ b/Package.resolved
@@ -9,6 +9,15 @@
           "revision": "10ed3b6736def7c26eb87135466b1cb46ea7e37f",
           "version": "2.4.0"
         }
+      },
+      {
+        "package": "KeychainAccess",
+        "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess.git",
+        "state": {
+          "branch": null,
+          "revision": "84e546727d66f1adc5439debad16270d0fdd04e7",
+          "version": "4.2.2"
+        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/airsidemobile/JOSESwift.git", from: "2.3.0"),
+        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -40,7 +41,7 @@ let package = Package(
         ),
         .target(
             name: "LogtoClient",
-            dependencies: ["Logto"]
+            dependencies: ["Logto", "KeychainAccess"]
         ),
         .testTarget(
             name: "LogtoClientTests",

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+PersistStorage.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+PersistStorage.swift
@@ -1,0 +1,49 @@
+//
+//  LogtoClient+PersistStorage.swift
+//  
+//
+//  Created by Gao Sun on 2022/2/4.
+//
+
+import Foundation
+
+extension LogtoClient {
+    enum KeyName: String {
+        case accessTokenMap = "access_token_map"
+        case idToken = "id_token"
+        case refreshToken = "refresh_token"
+    }
+    
+    static let keychainServiceName = "io.logto.client"
+    static let jsonEncoder = JSONEncoder()
+    
+    func loadFromKeychain() {
+        guard let keychain = keychain else {
+            return
+        }
+        
+        if let data = keychain[data: KeyName.accessTokenMap.rawValue], let jsonObject = try? JSONSerialization.jsonObject(with: data)  {
+            accessTokenMap = jsonObject as? [String: AccessToken] ?? [:]
+        }
+        
+        idToken = keychain[KeyName.idToken.rawValue]
+        refreshToken = keychain[KeyName.refreshToken.rawValue]
+    }
+    
+    func saveToKeychain(forKey key: KeyName) {
+        guard let keychain = keychain else {
+            return
+        }
+        
+        switch key {
+        case .accessTokenMap:
+            if let data = try? LogtoClient.jsonEncoder.encode(accessTokenMap) {
+                keychain[data: key.rawValue] = data
+            }
+        case .idToken:
+            keychain[key.rawValue] = idToken
+        case .refreshToken:
+            keychain[key.rawValue] = refreshToken
+        }
+    }
+}

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+PersistStorage.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+PersistStorage.swift
@@ -1,6 +1,6 @@
 //
 //  LogtoClient+PersistStorage.swift
-//  
+//
 //
 //  Created by Gao Sun on 2022/2/4.
 //
@@ -13,28 +13,30 @@ extension LogtoClient {
         case idToken = "id_token"
         case refreshToken = "refresh_token"
     }
-    
+
     static let keychainServiceName = "io.logto.client"
     static let jsonEncoder = JSONEncoder()
-    
+
     func loadFromKeychain() {
         guard let keychain = keychain else {
             return
         }
-        
-        if let data = keychain[data: KeyName.accessTokenMap.rawValue], let jsonObject = try? JSONSerialization.jsonObject(with: data)  {
+
+        if let data = keychain[data: KeyName.accessTokenMap.rawValue],
+           let jsonObject = try? JSONSerialization.jsonObject(with: data)
+        {
             accessTokenMap = jsonObject as? [String: AccessToken] ?? [:]
         }
-        
+
         idToken = keychain[KeyName.idToken.rawValue]
         refreshToken = keychain[KeyName.refreshToken.rawValue]
     }
-    
+
     func saveToKeychain(forKey key: KeyName) {
         guard let keychain = keychain else {
             return
         }
-        
+
         switch key {
         case .accessTokenMap:
             if let data = try? LogtoClient.jsonEncoder.encode(accessTokenMap) {

--- a/Sources/LogtoClient/LogtoClient/LogtoClient.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient.swift
@@ -7,28 +7,47 @@
 
 import Foundation
 import Logto
+import KeychainAccess
 
 public class LogtoClient {
+    // MARK: Internal Constants
     internal let authContext = LogtoAuthContext()
+    internal let keychain: Keychain?
     internal let logtoConfig: LogtoConfig
     internal let networkSession: NetworkSession
 
-    internal var accessTokenMap: [String: AccessToken] = [:]
-    internal var idToken: String?
-    internal var refreshToken: String?
-    internal var oidcConfig: LogtoCore.OidcConfigResponse?
+    // MARK: Internal Variables
+    internal var accessTokenMap: [String: AccessToken] = [:] {
+        didSet { saveToKeychain(forKey: .accessTokenMap) }
+    }
+    internal(set) public var idToken: String? {
+        didSet { saveToKeychain(forKey: .idToken) }
+    }
+    internal(set) public var refreshToken: String? {
+        didSet { saveToKeychain(forKey: .refreshToken) }
+    }
+    internal(set) public var oidcConfig: LogtoCore.OidcConfigResponse?
 
+    // MARK: Internal Functions
     internal func buildAccessTokenKey(for resource: String = "", scopes: [String]) -> String {
         "\(scopes.sorted().joined(separator: " "))@\(resource)"
     }
+    
+    // MARK: Public Computed Variables
+    public var isAuthenticated: Bool {
+        idToken != nil
+    }
 
+    // MARK: Public Init Functions
     public init(useConfig config: LogtoConfig, session: NetworkSession = URLSession.shared) {
         logtoConfig = config
         networkSession = session
-        // TO-DO: LOG-1398 set up and use persist storage if needed
-    }
-
-    public var isAuthenticated: Bool {
-        idToken != nil
+        
+        if config.usingPersistStorage {
+            keychain = Keychain(service: LogtoClient.keychainServiceName)
+            loadFromKeychain()
+        } else {
+            keychain = nil
+        }
     }
 }

--- a/Sources/LogtoClient/LogtoClient/LogtoClient.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient.swift
@@ -6,43 +6,51 @@
 //
 
 import Foundation
-import Logto
 import KeychainAccess
+import Logto
 
 public class LogtoClient {
     // MARK: Internal Constants
+
     internal let authContext = LogtoAuthContext()
     internal let keychain: Keychain?
     internal let logtoConfig: LogtoConfig
     internal let networkSession: NetworkSession
 
     // MARK: Internal Variables
+
     internal var accessTokenMap: [String: AccessToken] = [:] {
         didSet { saveToKeychain(forKey: .accessTokenMap) }
     }
-    internal(set) public var idToken: String? {
+
+    public internal(set) var idToken: String? {
         didSet { saveToKeychain(forKey: .idToken) }
     }
-    internal(set) public var refreshToken: String? {
+
+    public internal(set) var refreshToken: String? {
         didSet { saveToKeychain(forKey: .refreshToken) }
     }
-    internal(set) public var oidcConfig: LogtoCore.OidcConfigResponse?
+
+    public internal(set) var oidcConfig: LogtoCore.OidcConfigResponse?
 
     // MARK: Internal Functions
+
     internal func buildAccessTokenKey(for resource: String = "", scopes: [String]) -> String {
         "\(scopes.sorted().joined(separator: " "))@\(resource)"
     }
-    
+
     // MARK: Public Computed Variables
+
     public var isAuthenticated: Bool {
         idToken != nil
     }
 
     // MARK: Public Init Functions
+
     public init(useConfig config: LogtoConfig, session: NetworkSession = URLSession.shared) {
         logtoConfig = config
         networkSession = session
-        
+
         if config.usingPersistStorage {
             keychain = Keychain(service: LogtoClient.keychainServiceName)
             loadFromKeychain()

--- a/Sources/LogtoClient/LogtoClient/LogtoClient.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient.swift
@@ -23,6 +23,8 @@ public class LogtoClient {
         didSet { saveToKeychain(forKey: .accessTokenMap) }
     }
 
+    // MARK: Public Variables
+
     public internal(set) var idToken: String? {
         didSet { saveToKeychain(forKey: .idToken) }
     }

--- a/Sources/LogtoClient/Types/AccessToken.swift
+++ b/Sources/LogtoClient/Types/AccessToken.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct AccessToken {
+public struct AccessToken: Codable {
     let token: String
     let scope: String
     let expiresAt: Int64

--- a/Sources/LogtoClient/Types/LogtoConfig.swift
+++ b/Sources/LogtoClient/Types/LogtoConfig.swift
@@ -26,7 +26,7 @@ public struct LogtoConfig {
         clientId: String,
         scopes: [String] = [],
         resources: [String] = [],
-        usingPersistStorage: Bool = false
+        usingPersistStorage: Bool = true
     ) throws {
         guard let endpoint = URL(string: endpoint) else {
             throw LogtoErrors.UrlConstruction.unableToConstructUrl


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
use keychain as the persist storage to store `accessTokenMap`, `refreshToken` and `idToken`.

using fixed key since keychain is a per-app mechanism.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

print ID Token in demo when user has authenticated previously. unit tests will be covered later (LOG-1391).

![image](https://user-images.githubusercontent.com/14722250/152524418-bcff8e03-bb01-409f-9005-4385dceadc47.png)

<!-- MANDATORY -->
## Reviewers
<!-- Update if needed. -->

@logto-io/eng
