### PR TITLE
feat: `getAccessToken()`

### DIFF
--- a/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
+++ b/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
 
     init() {
         guard let config = try? LogtoConfig(
-            endpoint: "http://localhost:3001",
+            endpoint: "https://logto.dev",
             clientId: "z4skkM1Z8LLVSl1JCmVZO",
             resources: [resource]
         ) else {

--- a/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
+++ b/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
@@ -13,13 +13,14 @@ struct ContentView: View {
     @State var isAuthenticated: Bool
     @State var authError: Error?
 
+    let resource = "https://api.logto.io"
     let client: LogtoClient?
 
     init() {
         guard let config = try? LogtoConfig(
-            endpoint: "https://logto.dev",
+            endpoint: "http://localhost:3001",
             clientId: "z4skkM1Z8LLVSl1JCmVZO",
-            resources: ["https://api.logto.io"]
+            resources: [resource]
         ) else {
             client = nil
             isAuthenticated = false
@@ -80,10 +81,27 @@ struct ContentView: View {
             }
 
             Button("Fetch Userinfo") {
-                client.fetchUserInfo { userInfo, _ in
+                client.fetchUserInfo { userInfo, error in
+                    if let error = error?.innerError as? LogtoClient.Errors.AccessToken,
+                       let error = error.innerError as? LogtoErrors.Response,
+                       case let LogtoErrors.Response.withCode(
+                           _,
+                           _,
+                           data
+                       ) = error, let data = data
+                    {
+                        print(String(decoding: data, as: UTF8.self))
+                    }
+
                     if let userInfo = userInfo {
                         print(userInfo)
                     }
+                }
+            }
+
+            Button("Fetch access token for \(resource)") {
+                client.getAccessToken(for: resource) {
+                    print($0 ?? "N/A", $1 ?? "N/A")
                 }
             }
         }

--- a/Sources/Logto/Core/LogtoCore+Fetch.swift
+++ b/Sources/Logto/Core/LogtoCore+Fetch.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public extension LogtoCore {
     static let postHeaders: [String: String] = [
-        "Content-Type": "application/x-www-form-urlencoded",
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
     ]
 
     // MARK: OIDC Config
@@ -58,7 +58,6 @@ public extension LogtoCore {
         codeVerifier: String,
         tokenEndpoint: String,
         clientId: String,
-        resource: String?,
         redirectUri: String,
         completion: @escaping HttpCompletion<CodeTokenResponse>
     ) {
@@ -67,7 +66,6 @@ public extension LogtoCore {
             "code": code,
             "code_verifier": codeVerifier,
             "client_id": clientId,
-            "resource[]": resource,
             "redirect_uri": redirectUri,
         ]
 
@@ -103,7 +101,7 @@ public extension LogtoCore {
             "grant_type": TokenGrantType.refreshToken.rawValue,
             "refresh_token": refreshToken,
             "client_id": clientId,
-            "resource[]": resource,
+            "resource": resource,
             "scope": scopes.joined(separator: " "),
         ]
 

--- a/Sources/Logto/Core/LogtoCore+Fetch.swift
+++ b/Sources/Logto/Core/LogtoCore+Fetch.swift
@@ -80,7 +80,7 @@ public extension LogtoCore {
 
     struct RefreshTokenTokenResponse: Codable, Equatable {
         public let accessToken: String
-        public let refreshToken: String?
+        public let refreshToken: String
         public let idToken: String?
         public let scope: String
         public let expiresIn: Int64

--- a/Sources/Logto/Core/LogtoCore+Fetch.swift
+++ b/Sources/Logto/Core/LogtoCore+Fetch.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public extension LogtoCore {
     static let postHeaders: [String: String] = [
-        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "Content-Type": "application/x-www-form-urlencoded",
     ]
 
     // MARK: OIDC Config

--- a/Sources/Logto/Core/LogtoCore+Fetch.swift
+++ b/Sources/Logto/Core/LogtoCore+Fetch.swift
@@ -58,7 +58,7 @@ public extension LogtoCore {
         codeVerifier: String,
         tokenEndpoint: String,
         clientId: String,
-        resource: String? = nil,
+        resource: String?,
         redirectUri: String,
         completion: @escaping HttpCompletion<CodeTokenResponse>
     ) {
@@ -82,7 +82,7 @@ public extension LogtoCore {
 
     struct RefreshTokenTokenResponse: Codable, Equatable {
         public let accessToken: String
-        public let refreshToken: String
+        public let refreshToken: String?
         public let idToken: String?
         public let scope: String
         public let expiresIn: Int64
@@ -95,9 +95,9 @@ public extension LogtoCore {
         byRefreshToken refreshToken: String,
         tokenEndpoint: String,
         clientId: String,
-        resource: String? = nil,
-        scopes: [String] = [],
-        completion: @escaping HttpCompletion<CodeTokenResponse>
+        resource: String?,
+        scopes: [String],
+        completion: @escaping HttpCompletion<RefreshTokenTokenResponse>
     ) {
         let body: [String: String?] = [
             "grant_type": TokenGrantType.refreshToken.rawValue,

--- a/Sources/Logto/Core/LogtoCore+Generate.swift
+++ b/Sources/Logto/Core/LogtoCore+Generate.swift
@@ -43,7 +43,7 @@ public extension LogtoCore {
             URLQueryItem(name: "prompt", value: LogtoCore.prompt),
         ]
         let resourceQueryItems = resources.map {
-            URLQueryItem(name: "resource[]", value: $0)
+            URLQueryItem(name: "resource", value: $0)
         }
 
         components.queryItems = (baseQueryItems + resourceQueryItems).filter { $0.value != "" }

--- a/Sources/Logto/Extensions/Dictionary.swift
+++ b/Sources/Logto/Extensions/Dictionary.swift
@@ -13,6 +13,6 @@ extension Dictionary where Key == String, Value == String? {
         components.queryItems = compactMapValues { $0 }.compactMap {
             URLQueryItem(name: $0, value: $1)
         }
-        return components.query ?? ""
+        return components.percentEncodedQuery ?? ""
     }
 }

--- a/Sources/LogtoClient/LogtoAuthSession/LogtoAuthSession.swift
+++ b/Sources/LogtoClient/LogtoAuthSession/LogtoAuthSession.swift
@@ -96,7 +96,6 @@ public struct LogtoSignInSession {
                 codeVerifier: codeVerifier,
                 tokenEndpoint: oidcConfig.tokenEndpoint,
                 clientId: logtoConfig.clientId,
-                resource: "https://api.logto.io", // TO-DO: remove this line after core fixed
                 redirectUri: redirectUri.absoluteString
             ) {
                 guard let tokenResponse = $0 else {

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
@@ -1,0 +1,102 @@
+//
+//  LogtoClient+AccessToken.swift
+//
+//
+//  Created by Gao Sun on 2022/2/5.
+//
+
+import Foundation
+import Logto
+
+extension LogtoClient {
+    class AccessTokenMap {
+        var client: LogtoClient?
+        internal var accessTokenMap: [String: AccessToken] = [:]
+
+        var json: Data? {
+            try? LogtoClient.jsonEncoder.encode(accessTokenMap)
+        }
+
+        subscript(key: String) -> AccessToken? {
+            get {
+                accessTokenMap[key]
+            }
+
+            set {
+                accessTokenMap[key] = newValue
+                client?.saveToKeychain(forKey: .accessTokenMap)
+            }
+        }
+
+        func clear() {
+            accessTokenMap = [:]
+            client?.saveToKeychain(forKey: .accessTokenMap)
+        }
+
+        func assign(map: [String: AccessToken]) {
+            accessTokenMap = map
+            client?.saveToKeychain(forKey: .accessTokenMap)
+        }
+    }
+
+    func buildAccessTokenKey(for resource: String = "", scopes: [String]) -> String {
+        "\(scopes.sorted().joined(separator: " "))@\(resource)"
+    }
+
+    func getAccessToken(
+        for resource: String = "",
+        scopes: [String],
+        completion: @escaping Completion<String, Errors.AccessToken>
+    ) {
+        let key = buildAccessTokenKey(for: resource, scopes: scopes)
+
+        // Cached access token is still valid
+        if let accessToken = accessTokenMap[key], Date().timeIntervalSince1970 < accessToken.expiresAt {
+            completion(accessToken.token, nil)
+            return
+        }
+
+        // Use refresh token to fetch a new access token
+        guard let refreshToken = refreshToken else {
+            completion(nil, Errors.AccessToken(type: .noRefreshTokenFound, innerError: nil))
+            return
+        }
+
+        fetchOidcConfig { oidcConfig, error in
+            guard let oidcConfig = oidcConfig else {
+                completion(nil, Errors.AccessToken(type: .unableToFetchOidcConfig, innerError: error))
+                return
+            }
+
+            LogtoCore.fetchToken(
+                byRefreshToken: refreshToken,
+                tokenEndpoint: oidcConfig.tokenEndpoint,
+                clientId: self.logtoConfig.clientId,
+                resource: resource,
+                scopes: scopes
+            ) { response, error in
+                guard let response = response else {
+                    completion(nil, Errors.AccessToken(type: .unableToFetchTokenByRefreshToken, innerError: error))
+                    return
+                }
+
+                let accessToken = AccessToken(
+                    token: response.accessToken,
+                    scope: response.scope,
+                    expiresAt: Date().timeIntervalSince1970 + TimeInterval(response.expiresIn)
+                )
+                self.accessTokenMap[key] = accessToken
+
+                response.refreshToken.map {
+                    self.refreshToken = $0
+                }
+
+                response.idToken.map {
+                    self.idToken = $0
+                }
+
+                completion(accessToken.token, nil)
+            }
+        }
+    }
+}

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Logto
 
-extension LogtoClient {
+public extension LogtoClient {
     class AccessTokenMap {
         var client: LogtoClient?
         internal var accessTokenMap: [String: AccessToken] = [:]
@@ -39,16 +39,15 @@ extension LogtoClient {
         }
     }
 
-    func buildAccessTokenKey(for resource: String = "", scopes: [String]) -> String {
-        "\(scopes.sorted().joined(separator: " "))@\(resource)"
+    func buildAccessTokenKey(for resource: String?, scopes: [String]) -> String {
+        "\(scopes.sorted().joined(separator: " "))@\(resource ?? "")"
     }
 
     func getAccessToken(
-        for resource: String = "",
-        scopes: [String],
+        for resource: String?,
         completion: @escaping Completion<String, Errors.AccessToken>
     ) {
-        let key = buildAccessTokenKey(for: resource, scopes: scopes)
+        let key = buildAccessTokenKey(for: resource, scopes: [])
 
         // Cached access token is still valid
         if let accessToken = accessTokenMap[key], Date().timeIntervalSince1970 < accessToken.expiresAt {
@@ -73,7 +72,7 @@ extension LogtoClient {
                 tokenEndpoint: oidcConfig.tokenEndpoint,
                 clientId: self.logtoConfig.clientId,
                 resource: resource,
-                scopes: scopes
+                scopes: []
             ) { response, error in
                 guard let response = response else {
                     completion(nil, Errors.AccessToken(type: .unableToFetchTokenByRefreshToken, innerError: error))

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
@@ -84,11 +84,9 @@ public extension LogtoClient {
                     scope: response.scope,
                     expiresAt: Date().timeIntervalSince1970 + TimeInterval(response.expiresIn)
                 )
-                self.accessTokenMap[key] = accessToken
 
-                response.refreshToken.map {
-                    self.refreshToken = $0
-                }
+                self.accessTokenMap[key] = accessToken
+                self.refreshToken = response.refreshToken
 
                 response.idToken.map {
                     self.idToken = $0

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+Errors.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+Errors.swift
@@ -9,13 +9,34 @@ import Foundation
 
 public extension LogtoClient {
     enum Errors {
-        public struct Fetch: LogtoError, LocalizedError {
-            public enum FetchError {
+        public struct AccessToken: LogtoError, LocalizedError {
+            public enum AccessTokenError {
+                case noRefreshTokenFound
                 case unableToFetchOidcConfig
+                case unableToFetchTokenByRefreshToken
+            }
+
+            public let type: AccessTokenError
+            public let innerError: Error?
+        }
+
+        public struct OidcConfig: LogtoError, LocalizedError {
+            public enum OidcConfigError {
+                case unableToFetchOidcConfig
+            }
+
+            public let type: OidcConfigError
+            public let innerError: Error?
+        }
+
+        public struct UserInfo: LogtoError, LocalizedError {
+            public enum UserInfoError {
+                case unableToFetchOidcConfig
+                case unableToGetAccessToken
                 case unableToFetchUserInfo
             }
 
-            public let type: FetchError
+            public let type: UserInfoError
             public let innerError: Error?
         }
 

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+Fetch.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+Fetch.swift
@@ -39,7 +39,7 @@ extension LogtoClient {
                 return
             }
 
-            getAccessToken(scopes: []) { token, error in
+            getAccessToken(for: nil) { token, error in
                 guard let token = token else {
                     completion(nil, Errors.UserInfo(type: .unableToGetAccessToken, innerError: error))
                     return

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+PersistStorage.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+PersistStorage.swift
@@ -16,6 +16,7 @@ extension LogtoClient {
 
     static let keychainServiceName = "io.logto.client"
     static let jsonEncoder = JSONEncoder()
+    static let jsonDecoder = JSONDecoder()
 
     func loadFromKeychain() {
         guard let keychain = keychain else {
@@ -23,9 +24,9 @@ extension LogtoClient {
         }
 
         if let data = keychain[data: KeyName.accessTokenMap.rawValue],
-           let jsonObject = try? JSONSerialization.jsonObject(with: data)
+           let tokenMap = try? LogtoClient.jsonDecoder.decode([String: AccessToken].self, from: data)
         {
-            accessTokenMap = jsonObject as? [String: AccessToken] ?? [:]
+            accessTokenMap.assign(map: tokenMap)
         }
 
         idToken = keychain[KeyName.idToken.rawValue]
@@ -39,7 +40,7 @@ extension LogtoClient {
 
         switch key {
         case .accessTokenMap:
-            if let data = try? LogtoClient.jsonEncoder.encode(accessTokenMap) {
+            if let data = accessTokenMap.json {
                 keychain[data: key.rawValue] = data
             }
         case .idToken:

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
@@ -33,12 +33,11 @@ public extension LogtoClient {
                 case let .success(response):
                     idToken = response.idToken
                     refreshToken = response.refreshToken
-                    accessTokenMap[buildAccessTokenKey(scopes: [])] = AccessToken(
+                    accessTokenMap[buildAccessTokenKey(for: nil, scopes: [])] = AccessToken(
                         token: response.accessToken,
                         scope: response.scope,
                         expiresAt: Date().timeIntervalSince1970 + TimeInterval(response.expiresIn)
                     )
-                    print("success", response)
                     completion(.success)
                 }
             }

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
@@ -36,7 +36,7 @@ public extension LogtoClient {
                     accessTokenMap[buildAccessTokenKey(scopes: [])] = AccessToken(
                         token: response.accessToken,
                         scope: response.scope,
-                        expiresAt: Int64(Date().timeIntervalSince1970 * 1000) + response.expiresIn
+                        expiresAt: Date().timeIntervalSince1970 + TimeInterval(response.expiresIn)
                     )
                     print("success", response)
                     completion(.success)

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
@@ -32,7 +32,7 @@ public extension LogtoClient {
             }
         }
 
-        accessTokenMap = [:]
+        accessTokenMap.clear()
         refreshToken = nil
         idToken = nil
     }

--- a/Sources/LogtoClient/LogtoClient/LogtoClient.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient.swift
@@ -19,9 +19,7 @@ public class LogtoClient {
 
     // MARK: Internal Variables
 
-    internal var accessTokenMap: [String: AccessToken] = [:] {
-        didSet { saveToKeychain(forKey: .accessTokenMap) }
-    }
+    internal var accessTokenMap = AccessTokenMap()
 
     // MARK: Public Variables
 
@@ -34,12 +32,6 @@ public class LogtoClient {
     }
 
     public internal(set) var oidcConfig: LogtoCore.OidcConfigResponse?
-
-    // MARK: Internal Functions
-
-    internal func buildAccessTokenKey(for resource: String = "", scopes: [String]) -> String {
-        "\(scopes.sorted().joined(separator: " "))@\(resource)"
-    }
 
     // MARK: Public Computed Variables
 
@@ -65,6 +57,7 @@ public class LogtoClient {
 
         if config.usingPersistStorage {
             keychain = Keychain(service: LogtoClient.keychainServiceName)
+            accessTokenMap.client = self
             loadFromKeychain()
         } else {
             keychain = nil

--- a/Sources/LogtoClient/Types/AccessToken.swift
+++ b/Sources/LogtoClient/Types/AccessToken.swift
@@ -10,5 +10,5 @@ import Foundation
 public struct AccessToken: Codable {
     let token: String
     let scope: String
-    let expiresAt: Int64
+    let expiresAt: TimeInterval
 }

--- a/Tests/LogtoTests/LogtoCoreTests+Fetch.swift
+++ b/Tests/LogtoTests/LogtoCoreTests+Fetch.swift
@@ -76,7 +76,9 @@ extension LogtoCoreTests {
             useSession: NetworkSessionMock.shared,
             byRefreshToken: "123",
             tokenEndpoint: "/token:bad",
-            clientId: "foo"
+            clientId: "foo",
+            resource: nil,
+            scopes: []
         ) {
             XCTAssertNil($0)
             XCTAssertNotNil($1)

--- a/Tests/LogtoTests/LogtoCoreTests+Generate.swift
+++ b/Tests/LogtoTests/LogtoCoreTests+Generate.swift
@@ -83,7 +83,7 @@ extension LogtoCoreTests {
         try validateBaseInformation(url: url1)
         XCTAssertEqual(
             url1.query,
-            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=code&prompt=consent&resource%5B%5D=https://api.logto.dev/"
+            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=code&prompt=consent&resource=https://api.logto.dev/"
         )
 
         let url2 = try LogtoCore.generateSignInUri(
@@ -97,7 +97,7 @@ extension LogtoCoreTests {
         try validateBaseInformation(url: url2)
         XCTAssertEqual(
             url2.query,
-            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=code&prompt=consent&resource%5B%5D=https://api.logto.dev/&resource%5B%5D=bar"
+            "client_id=foo&redirect_uri=logto://sign-in/redirect&code_challenge=\(codeChallenge)&code_challenge_method=S256&state=\(state)&scope=offline_access%20openid&response_type=code&prompt=consent&resource=https://api.logto.dev/&resource=bar"
         )
     }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- implement `getAccessToken()`
- use `getAccessToken()` in `fetchUserInfo()`

To-do:
- LOG-1464 Fetch token by refresh token always returns id token
- add unit tests (will do in the separate PR)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

tested with `fetchUserInfo()`

- [x] when user is not authenticated, throws `.noRefreshTokenFound`
- [x] when user is authenticated and cached access token is valid, use cached token to fetch user info
- [x] when user is authenticated and cached access token is not valid (expired), use refresh token to fetch a new access token and update local tokens accordingly, then fetch user info

<!-- MANDATORY -->
## Reviewers
<!-- Update if needed. -->

@logto-io/eng
