### PR TITLE
refactor(client): use async

### DIFF
--- a/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
@@ -13,30 +13,22 @@ public extension LogtoClient {
         "\(scopes.sorted().joined(separator: " "))@\(resource ?? "")"
     }
 
-    func getAccessToken(
-        for resource: String?,
-        completion: @escaping Completion<String, Errors.AccessToken>
-    ) {
+    func getAccessToken(for resource: String?) async throws -> String {
         let key = buildAccessTokenKey(for: resource, scopes: [])
 
         // Cached access token is still valid
         if let accessToken = accessTokenMap[key], Date().timeIntervalSince1970 < accessToken.expiresAt {
-            completion(accessToken.token, nil)
-            return
+            return accessToken.token
         }
 
         // Use refresh token to fetch a new access token
         guard let refreshToken = refreshToken else {
-            completion(nil, Errors.AccessToken(type: .noRefreshTokenFound, innerError: nil))
-            return
+            throw Errors.AccessToken(type: .noRefreshTokenFound, innerError: nil)
         }
 
-        fetchOidcConfig { oidcConfig, error in
-            guard let oidcConfig = oidcConfig else {
-                completion(nil, Errors.AccessToken(type: .unableToFetchOidcConfig, innerError: error))
-                return
-            }
+        let oidcConfig = try await fetchOidcConfig()
 
+        return try await withCheckedThrowingContinuation { continuation in
             LogtoCore.fetchToken(
                 useSession: self.networkSession,
                 byRefreshToken: refreshToken,
@@ -46,7 +38,9 @@ public extension LogtoClient {
                 scopes: []
             ) { response, error in
                 guard let response = response else {
-                    completion(nil, Errors.AccessToken(type: .unableToFetchTokenByRefreshToken, innerError: error))
+                    continuation
+                        .resume(throwing: Errors
+                            .AccessToken(type: .unableToFetchTokenByRefreshToken, innerError: error))
                     return
                 }
 
@@ -63,7 +57,7 @@ public extension LogtoClient {
                     self.idToken = $0
                 }
 
-                completion(accessToken.token, nil)
+                continuation.resume(returning: accessToken.token)
             }
         }
     }

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+Fetch.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+Fetch.swift
@@ -9,56 +9,48 @@ import Foundation
 import Logto
 
 extension LogtoClient {
-    internal func fetchOidcConfig(completion: @escaping HttpCompletion<LogtoCore.OidcConfigResponse>) {
-        guard oidcConfig == nil else {
-            completion(oidcConfig, nil)
-            return
+    internal func fetchOidcConfig() async throws -> LogtoCore.OidcConfigResponse {
+        if let config = oidcConfig {
+            return config
         }
 
-        let requestCompletion: HttpCompletion<LogtoCore.OidcConfigResponse> = { config, error in
-            if error != nil || config == nil {
-                completion(nil, Errors.OidcConfig(type: .unableToFetchOidcConfig, innerError: error))
-                return
-            }
-
-            self.oidcConfig = config
-            completion(config, nil)
-        }
-
-        LogtoRequest.get(
-            useSession: networkSession,
-            url: logtoConfig.endpoint.appendingPathComponent("/oidc/.well-known/openid-configuration"),
-            completion: requestCompletion
-        )
-    }
-
-    public func fetchUserInfo(completion: @escaping Completion<LogtoCore.UserInfoResponse, Errors.UserInfo>) {
-        fetchOidcConfig { [self] oidcConfig, error in
-            guard let oidcConfig = oidcConfig else {
-                completion(nil, Errors.UserInfo(type: .unableToFetchOidcConfig, innerError: error))
-                return
-            }
-
-            getAccessToken(for: nil) { token, error in
-                guard let token = token else {
-                    completion(nil, Errors.UserInfo(type: .unableToGetAccessToken, innerError: error))
+        return try await withCheckedThrowingContinuation { continuation in
+            let completion: Completion<LogtoCore.OidcConfigResponse, Error> = { config, error in
+                guard error == nil, let config = config else {
+                    continuation.resume(throwing: Errors.OidcConfig(type: .unableToFetchOidcConfig, innerError: error))
                     return
                 }
 
-                LogtoCore
-                    .fetchUserInfo(
-                        useSession: self.networkSession,
-                        userInfoEndpoint: oidcConfig.userinfoEndpoint,
-                        accessToken: token
-                    ) { userInfo, error in
-                        guard let userInfo = userInfo else {
-                            completion(nil, Errors.UserInfo(type: .unableToFetchUserInfo, innerError: error))
-                            return
-                        }
-
-                        completion(userInfo, nil)
-                    }
+                self.oidcConfig = config
+                continuation.resume(returning: config)
             }
+
+            LogtoRequest.get(
+                useSession: networkSession,
+                url: logtoConfig.endpoint.appendingPathComponent("/oidc/.well-known/openid-configuration"),
+                completion: completion
+            )
+        }
+    }
+
+    public func fetchUserInfo() async throws -> LogtoCore.UserInfoResponse {
+        let oidcConfig = try await fetchOidcConfig()
+        let token = try await getAccessToken(for: nil)
+
+        return try await withCheckedThrowingContinuation { continuation in
+            LogtoCore
+                .fetchUserInfo(
+                    useSession: self.networkSession,
+                    userInfoEndpoint: oidcConfig.userinfoEndpoint,
+                    accessToken: token
+                ) { userInfo, error in
+                    guard let userInfo = userInfo else {
+                        continuation.resume(throwing: Errors.UserInfo(type: .unableToFetchUserInfo, innerError: error))
+                        return
+                    }
+
+                    continuation.resume(returning: userInfo)
+                }
         }
     }
 }

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
@@ -14,43 +14,45 @@ extension LogtoClient {
         authSessionType _: AuthSession.Type,
         redirectUri: String,
         completion: @escaping EmptyCompletion<Errors.SignIn>
-    ) {
+    ) async throws {
         guard let redirectUri = URL(string: redirectUri) else {
             completion(Errors.SignIn(type: .unableToConstructRedirectUri, innerError: nil))
             return
         }
 
-        fetchOidcConfig { [self] oidcConfig, error in
-            guard let oidcConfig = oidcConfig else {
-                completion(Errors.SignIn(type: .unableToFetchOidcConfig, innerError: error))
-                return
-            }
+        let oidcConfig = try await fetchOidcConfig()
 
-            let session = AuthSession(
-                logtoConfig: logtoConfig,
-                oidcConfig: oidcConfig,
-                redirectUri: redirectUri
-            ) { [self] in
-                switch $0 {
-                case let .failure(error):
-                    completion(error)
-                case let .success(response):
-                    idToken = response.idToken
-                    refreshToken = response.refreshToken
-                    accessTokenMap[buildAccessTokenKey(for: nil, scopes: [])] = AccessToken(
-                        token: response.accessToken,
-                        scope: response.scope,
-                        expiresAt: Date().timeIntervalSince1970 + TimeInterval(response.expiresIn)
-                    )
-                    completion(nil)
-                }
+        let session = AuthSession(
+            logtoConfig: logtoConfig,
+            oidcConfig: oidcConfig,
+            redirectUri: redirectUri
+        ) { [self] in
+            switch $0 {
+            case let .failure(error):
+                completion(error)
+            case let .success(response):
+                idToken = response.idToken
+                refreshToken = response.refreshToken
+                accessTokenMap[buildAccessTokenKey(for: nil, scopes: [])] = AccessToken(
+                    token: response.accessToken,
+                    scope: response.scope,
+                    expiresAt: Date().timeIntervalSince1970 + TimeInterval(response.expiresIn)
+                )
+                completion(nil)
             }
-
-            session.start()
         }
+
+        session.start()
     }
 
-    public func signInWithBrowser(redirectUri: String, completion: @escaping EmptyCompletion<Errors.SignIn>) {
-        signInWithBrowser(authSessionType: LogtoAuthSession.self, redirectUri: redirectUri, completion: completion)
+    public func signInWithBrowser(
+        redirectUri: String,
+        completion: @escaping EmptyCompletion<Errors.SignIn>
+    ) async throws {
+        try await signInWithBrowser(
+            authSessionType: LogtoAuthSession.self,
+            redirectUri: redirectUri,
+            completion: completion
+        )
     }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
use `async` for LogtoClient methods

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT

<!-- MANDATORY -->
## Reviewers
<!-- Update if needed. -->

@logto-io/eng
