### PR TITLE
refactor(client): cache get token task

### DIFF
--- a/Sources/LogtoClient/LogtoClient/LogtoClient.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient.swift
@@ -20,6 +20,7 @@ public class LogtoClient {
     // MARK: Internal Variables
 
     internal var accessTokenMap = [String: AccessToken]()
+    internal var getAccessTokenTaskMap = [String: Task<String, Error>]()
 
     // MARK: Public Variables
 

--- a/Tests/LogtoMock/NetworkSessionMock.swift
+++ b/Tests/LogtoMock/NetworkSessionMock.swift
@@ -13,6 +13,8 @@ public class MockError: LocalizedError {}
 public class NetworkSessionMock: NetworkSession {
     public static let shared = NetworkSessionMock()
 
+    public var tokenRequestCount = 0
+
     public func loadData(
         with request: URLRequest,
         completion: @escaping HttpCompletion<Data>
@@ -61,6 +63,22 @@ public class NetworkSessionMock: NetworkSession {
         case "POST":
             switch request.url?.pathComponents[safe: 1] {
             case "token:good":
+                tokenRequestCount += 1
+
+                guard tokenRequestCount <= 1 else {
+                    completion(Data("""
+                        {
+                            "access_token": "456",
+                            "refresh_token": "789",
+                            "id_token": "abc",
+                            "token_type": "jwt",
+                            "scope": "",
+                            "expires_in": 123
+                        }
+                    """.utf8), nil)
+                    return
+                }
+
                 completion(Data("""
                     {
                         "access_token": "123",


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

cache `getTokenByRefreshToken` task to avoid race condition in concurrent calls

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1902

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT

<!-- MANDATORY -->
## Reviewers
<!-- Update if needed. -->

@logto-io/eng
