### PR TITLE
refactor(client): remove unnecessary error enums

### DIFF
--- a/Sources/LogtoClient/LogtoClient/LogtoClient+Errors.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+Errors.swift
@@ -12,7 +12,6 @@ public extension LogtoClient {
         public struct AccessToken: LogtoError, LocalizedError {
             public enum AccessTokenError {
                 case noRefreshTokenFound
-                case unableToFetchOidcConfig
                 case unableToFetchTokenByRefreshToken
             }
 
@@ -31,8 +30,6 @@ public extension LogtoClient {
 
         public struct UserInfo: LogtoError, LocalizedError {
             public enum UserInfoError {
-                case unableToFetchOidcConfig
-                case unableToGetAccessToken
                 case unableToFetchUserInfo
             }
 
@@ -48,7 +45,6 @@ public extension LogtoClient {
             public enum SignInError: String {
                 case unknownError
                 case authFailed
-                case unableToFetchOidcConfig
                 case unableToConstructRedirectUri
                 case unableToConstructAuthUri
                 case unableToFetchToken
@@ -62,7 +58,6 @@ public extension LogtoClient {
         public struct SignOut: LogtoError {
             public enum SignOutError: String {
                 case unableToRevokeToken
-                case unableToFetchOidcConfig
             }
 
             public let type: SignOutError


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
remove unused error enums in `LogtoClient`

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2039

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT

<!-- MANDATORY -->
## Reviewers
<!-- Update if needed. -->

@logto-io/eng
