### PR TITLE
feat(client): web social sign in

### DIFF
--- a/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthViewController.swift
+++ b/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Gao Sun on 2022/3/22.
 //
 
+import AuthenticationServices
 import Foundation
 import WebKit
 
@@ -25,9 +26,80 @@ public class LogtoWebViewAuthViewController: UnifiedViewController {
     override public func loadView() {
         view = webView
         webView.navigationDelegate = authSession
+        webView.configuration.userContentController.add(self, name: "socialHandler")
     }
 
     override public func viewDidLoad() {
         webView.load(URLRequest(url: authSession.uri))
+    }
+
+    func postErrorMessage(_ error: LogtoWebViewAuthViewError) {
+        webView.evaluateJavaScript("""
+            window.postMessage({
+                type: 'error',
+                code: '\(error.code)',
+                description: '\(error.localizedDescription)'
+            }, location.origin);
+        """)
+    }
+}
+
+extension LogtoWebViewAuthViewController: ASWebAuthenticationPresentationContextProviding {
+    public func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        view.window!
+    }
+}
+
+extension LogtoWebViewAuthViewController: WKScriptMessageHandler {
+    static let webAuthCallbackScheme = "logto-callback"
+
+    struct SocialPostBody: Codable {
+        static func safeParseJson(json: Any) -> SocialPostBody? {
+            do {
+                let data = try JSONSerialization.data(withJSONObject: json)
+                return try? JSONDecoder().decode(self, from: data)
+            } catch {
+                return nil
+            }
+        }
+
+        let callbackUri: String
+        let redirectTo: String
+    }
+
+    public func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard let body = SocialPostBody.safeParseJson(json: message.body),
+              let redirectUri = URL(string: body.redirectTo),
+              let callbackUri = URL(string: body.callbackUri),
+              var callbackComponents = URLComponents(url: callbackUri, resolvingAgainstBaseURL: true)
+        else {
+            return
+        }
+
+        let session = ASWebAuthenticationSession(
+            url: redirectUri,
+            callbackURLScheme: LogtoWebViewAuthViewController.webAuthCallbackScheme
+        ) { [self] customUri, error in
+            guard let customUri = customUri else {
+                postErrorMessage(.webAuthFailed(innerError: error))
+                return
+            }
+
+            // Construct callback URL for WebView
+            let customComponents = URLComponents(url: customUri, resolvingAgainstBaseURL: true)
+            callbackComponents
+                .queryItems = (callbackComponents.queryItems ?? []) + (customComponents?.queryItems ?? [])
+
+            guard let url = callbackComponents.url else {
+                postErrorMessage(.unableToConstructCallbackUri)
+                return
+            }
+
+            self.webView.load(URLRequest(url: url))
+        }
+
+        session.prefersEphemeralWebBrowserSession = true
+        session.presentationContextProvider = self
+        session.start()
     }
 }

--- a/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthViewError.swift
+++ b/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthViewError.swift
@@ -1,0 +1,31 @@
+//
+//  LogtoWebViewAuthViewError.swift
+//
+//
+//  Created by Gao Sun on 2022/3/29.
+//
+
+import Foundation
+
+enum LogtoWebViewAuthViewError: LocalizedError {
+    case webAuthFailed(innerError: Error?)
+    case unableToConstructCallbackUri
+
+    var code: String {
+        switch self {
+        case .webAuthFailed:
+            return "web_auth_failed"
+        case .unableToConstructCallbackUri:
+            return "unable_to_construct_callback_uri"
+        }
+    }
+
+    var localizedDescription: String {
+        switch self {
+        case let .webAuthFailed(innerError):
+            return innerError?.localizedDescription ?? "Web authentication failed."
+        case .unableToConstructCallbackUri:
+            return "Unable to construct callback URI."
+        }
+    }
+}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
implement web social sign in callback and error handler.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1514

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Normal flow

1. Click "social" then open GitHub auth session
<img width="377" alt="image" src="https://user-images.githubusercontent.com/14722250/160591294-b34a07db-2d25-42db-8e89-b706a12f9acc.png">
<img width="5" alt="image" src="https://user-images.githubusercontent.com/14722250/160591511-94c57518-b6e3-4f91-9871-35be31eb4993.png">

2. Sign in, then successfully get code
<img width="190" alt="image" src="https://user-images.githubusercontent.com/14722250/160591654-17bfb67f-3af9-44b7-a93b-63cf786bdfe1.png">

### Error handling
1. Click "social" then open GitHub auth session
2. Directly close the session w/o signing in, shows a error toast

<img width="399" alt="image" src="https://user-images.githubusercontent.com/14722250/160591774-0d828ef2-f422-42c2-84a5-84ecd3e92900.png">

## UI Code Reference

<details>
<summary>Click to expand</summary>

```tsx
// Sign in component
useEffect(() => {
  window.addEventListener('message', function (event) {
    if (event.origin === location.origin) {
      setToast(JSON.stringify(event.data));
    }
  });
}, []);

// `redirectTo` is the result of `POST /api/session/sign-in/social`
<Button
  onClick={() => {
    const { socialHandler } = window.webkit?.messageHandlers ?? {};
    socialHandler?.postMessage({
      callbackUri: 'http://localhost:3001/foo', // this should be the same as normal callback url when implement
      redirectTo:
        'https://github.com/login/oauth/authorize?client_id=...',
    });
  }}
>
  social
</Button>

// Route components
const GitHub = () => {
  useEffect(() => {
    window.location.assign(`logto-callback://github${window.location.search}`);
  }, []);

  return <div>loading</div>;
};

const Foo = () => {
  return <div>success: {window.location.href}</div>;
};

// Added routes
<Route exact path="/callback/github" component={GitHub} />
<Route exact path="/foo" component={Foo} /> // should merge into `/callback`
```

</details>

<!-- MANDATORY -->
## Reviewers
<!-- Update if needed. -->

@logto-io/eng
