### PR TITLE
refactor(client): assert constant instead of magic string

### DIFF
--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
@@ -28,19 +28,16 @@ extension LogtoClient {
         )
 
         let response = try await session.start()
+        let jwks = try await fetchJwkSet()
+
+        try LogtoUtilities.verifyIdToken(
+            response.idToken,
+            issuer: oidcConfig.issuer,
+            clientId: logtoConfig.clientId,
+            jwks: jwks
+        )
 
         idToken = response.idToken
-
-        if let idToken = idToken {
-            let jwks = try await fetchJwkSet()
-            try LogtoUtilities.verifyIdToken(
-                idToken,
-                issuer: oidcConfig.issuer,
-                clientId: logtoConfig.clientId,
-                jwks: jwks
-            )
-        }
-
         refreshToken = response.refreshToken
         accessTokenMap[buildAccessTokenKey(for: nil, scopes: [])] = AccessToken(
             token: response.accessToken,

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+AccessToken.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+AccessToken.swift
@@ -6,15 +6,16 @@ import XCTest
 extension LogtoClientTests {
     func testGetAccessTokenCached() async throws {
         let client = buildClient()
+        let cachedAccessToken = "foo"
 
         client.accessTokenMap[client.buildAccessTokenKey(for: nil, scopes: [])] = AccessToken(
-            token: "foo",
+            token: cachedAccessToken,
             scope: "",
             expiresAt: Date().timeIntervalSince1970 + 1000
         )
 
         let token = try await client.getAccessToken(for: nil)
-        XCTAssertEqual(token, "foo")
+        XCTAssertEqual(token, cachedAccessToken)
     }
 
     func testGetAccessTokenByRefreshToken() async throws {

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignIn.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignIn.swift
@@ -25,7 +25,7 @@ class LogtoAuthSessionFailureMock: LogtoAuthSession {
 
 extension LogtoClientTests {
     func testSignInUnableToFetchJwkSet() async throws {
-        let client = buildClient()
+        let client = buildClient(withToken: true)
 
         do {
             try await client.signInWithBrowser(
@@ -34,7 +34,7 @@ extension LogtoClientTests {
             )
         } catch let error as LogtoClient.Errors.JwkSet {
             XCTAssertEqual(error.type, .unableToFetchJwkSet)
-            XCTAssertEqual(client.idToken, "baz")
+            XCTAssertEqual(client.idToken, initialIdToken)
             return
         }
 

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests.swift
@@ -4,6 +4,9 @@ import LogtoMock
 import XCTest
 
 final class LogtoClientTests: XCTestCase {
+    let initialRefreshToken = "foo"
+    let initialIdToken = "bar"
+
     func buildClient(withOidcEndpoint endpoint: String = "/oidc_config:good", withToken: Bool = false) -> LogtoClient {
         let client = LogtoClient(
             useConfig: try! LogtoConfig(endpoint: endpoint, clientId: "foo", usingPersistStorage: false),
@@ -11,8 +14,8 @@ final class LogtoClientTests: XCTestCase {
         )
 
         if withToken {
-            client.refreshToken = "foo"
-            client.idToken = "bar"
+            client.refreshToken = initialRefreshToken
+            client.idToken = initialIdToken
             client.accessTokenMap = [
                 "scope@resource": AccessToken(token: "", scope: "", expiresAt: 1),
             ]


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- assert constant if possible instead of magic string
- fix ID Token validation order

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1526

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT

<!-- MANDATORY -->
## Reviewers
<!-- Update if needed. -->

@logto-io/eng
