### PR TITLE
fix(client): clear cookie when WebView disappeared

### DIFF
--- a/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthViewController.swift
+++ b/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthViewController.swift
@@ -61,7 +61,7 @@ class LogtoWebViewAuthViewController: UnifiedViewController {
     override public func viewDidDisappear(_: Bool) {
         Task {
             await authSession.didFinish(url: nil)
-            
+
             // Delete related cookies asyncly when view disappeared
             if let host = authSession.uri.host {
                 WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in

--- a/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthViewController.swift
+++ b/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthViewController.swift
@@ -61,6 +61,17 @@ class LogtoWebViewAuthViewController: UnifiedViewController {
     override public func viewDidDisappear(_: Bool) {
         Task {
             await authSession.didFinish(url: nil)
+            
+            // Delete related cookies asyncly when view disappeared
+            if let host = authSession.uri.host {
+                WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
+                    cookies.forEach {
+                        if $0.domain == host {
+                            WKWebsiteDataStore.default().httpCookieStore.delete($0)
+                        }
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
WKWebView will not clear cookie automatically, thus consent will be performed after sign-out.

we need to clear it manually when WebView is closed

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
sign in -> finish -> sign in again -> show initial UI

<!-- MANDATORY -->
## Reviewers
<!-- Update if needed. -->

@logto-io/eng
