### PR TITLE
fix(swift): getAccessTokenByRefreshToken should not return idToken

### DIFF
--- a/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
@@ -24,7 +24,7 @@ extension LogtoClient {
                 tokenEndpoint: oidcConfig.tokenEndpoint,
                 clientId: logtoConfig.appId,
                 resource: resource,
-                scopes: []
+                scopes: ["offline_access"] // Force pass in offline_access as scope to avoid idtoke being returned
             )
 
             let accessToken = AccessToken(

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
@@ -24,7 +24,7 @@ extension LogtoClient {
                 tokenEndpoint: oidcConfig.tokenEndpoint,
                 clientId: logtoConfig.appId,
                 resource: resource,
-                scopes: ["offline_access"] // Force pass in offline_access as scope to avoid idtoke being returned
+                scopes: ["offline_access"] // Force pass in offline_access as scope to avoid ID Token being returned
             )
 
             let accessToken = AccessToken(


### PR DESCRIPTION

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
getAccessTokenByRefreshToken should not return idToken


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT passed

<!-- MANDATORY -->
## Reviewers
<!-- Update if needed. -->

@logto-io/eng
@gao-sun 