### PR TITLE
refactor: remove getAccessToken concurrent map

### DIFF
--- a/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
@@ -69,23 +69,12 @@ extension LogtoClient {
             return accessToken.token
         }
 
-        // Check existing task
-        if let task = getAccessTokenTaskMap[key] {
-            return try await task.value
-        }
-
         // Use refresh token to fetch a new access token
         guard let refreshToken = refreshToken else {
             throw LogtoClientErrors.AccessToken(type: .noRefreshTokenFound, innerError: nil)
         }
 
-        let task = Task {
-            try await self.getAccessToken(by: refreshToken, for: resource)
-        }
-        getAccessTokenTaskMap.updateValue(task, forKey: key)
-
-        let token = try await task.value
-        getAccessTokenTaskMap.removeValue(forKey: key)
+        let token = try await getAccessToken(by: refreshToken, for: resource)
 
         return token
     }

--- a/Sources/LogtoClient/LogtoClient/LogtoClient.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient.swift
@@ -48,7 +48,6 @@ public class LogtoClient {
     // MARK: Internal Variables
 
     internal var accessTokenMap = [String: AccessToken]()
-    internal var getAccessTokenTaskMap = [String: Task<String, Error>]()
 
     // MARK: Public Variables
 

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+AccessToken.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+AccessToken.swift
@@ -34,7 +34,7 @@ extension LogtoClientTests {
         let tokens = try await [get1, get2]
 
         XCTAssertEqual(tokens[0], "123")
-        XCTAssertEqual(tokens[1], "123")
+        XCTAssertEqual(tokens[1], "456")
     }
 
     func testGetAccessTokenUnalbeToFetchOidcConfig() async throws {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Since it's for single resource only, which is actually useless when rotate Refresh Token enabled.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- [x] sign in and fetch userinfo
- [x] close app and fetch userinfo using refreshed access token