### PR TITLE
refactor: remove forced scope when fetching access token

### DIFF
--- a/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
@@ -14,10 +14,6 @@ extension LogtoClient {
     }
 
     func getAccessToken(by refreshToken: String, for resource: String?) async throws -> String {
-        // Force pass in offline_access as scope to avoid ID Token being returned
-        let scopes = resource == nil ?
-            nil :
-            [LogtoUtilities.Scope.offlineAccess.rawValue]
         let key = buildAccessTokenKey(for: resource)
         let oidcConfig = try await fetchOidcConfig()
 
@@ -28,7 +24,7 @@ extension LogtoClient {
                 tokenEndpoint: oidcConfig.tokenEndpoint,
                 clientId: logtoConfig.appId,
                 resource: resource,
-                scopes: scopes
+                scopes: nil
             )
 
             let accessToken = AccessToken(


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
as we need to fetch available scopes for access tokens

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

pass valid scope in `LogtoConfig`, then fetch access token:

<img width="434" alt="image" src="https://user-images.githubusercontent.com/14722250/215665076-f3de2742-ccf9-486a-a981-51500f47f8f9.png">
