### PR TITLE
feat: add extraParams to pass custom authorization parameters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,9 @@ jobs:
           path: BuildTools/.build
           key: ${{ runner.os }}-spm-v1-${{ hashFiles('BuildTools/Package.resolved') }}
 
-      - run: sudo xcode-select -s /Applications/Xcode_14.1.app
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       - name: SwiftFormat
         run: |

--- a/Sources/Logto/Core/LogtoCore+Generate.swift
+++ b/Sources/Logto/Core/LogtoCore+Generate.swift
@@ -24,7 +24,8 @@ public extension LogtoCore {
         state: String,
         scopes: [String] = [],
         resources: [String] = [],
-        prompt: Prompt = .consent
+        prompt: Prompt = .consent,
+        extraParams: [String: String]? = nil
     ) throws -> URL {
         guard
             var components = URLComponents(string: authorizationEndpoint),
@@ -51,7 +52,11 @@ public extension LogtoCore {
             URLQueryItem(name: "resource", value: $0)
         }
 
-        components.queryItems = (baseQueryItems + resourceQueryItems).filter { $0.value != "" }
+        let extraParamsQueryItems = extraParams?.map {
+            URLQueryItem(name: $0.key, value: $0.value)
+        } ?? []
+
+        components.queryItems = (baseQueryItems + resourceQueryItems + extraParamsQueryItems).filter { $0.value != "" }
 
         guard let url = components.url else {
             throw LogtoErrors.UrlConstruction.unableToConstructUrl

--- a/Sources/LogtoClient/LogtoAuthSession/LogtoAuthSession.swift
+++ b/Sources/LogtoClient/LogtoAuthSession/LogtoAuthSession.swift
@@ -22,6 +22,7 @@ class LogtoAuthSession {
     let oidcConfig: LogtoCore.OidcConfigResponse
     let redirectUri: URL
     let socialPlugins: [LogtoSocialPlugin]
+    let extraParams: [String: String]?
 
     internal var callbackUri: URL?
 
@@ -30,7 +31,8 @@ class LogtoAuthSession {
         logtoConfig: LogtoConfig,
         oidcConfig: LogtoCore.OidcConfigResponse,
         redirectUri: URL,
-        socialPlugins: [LogtoSocialPlugin]
+        socialPlugins: [LogtoSocialPlugin],
+        extraParams: [String: String]? = nil
     ) {
         authContext = LogtoAuthContext()
         state = LogtoUtilities.generateState()
@@ -42,6 +44,7 @@ class LogtoAuthSession {
         self.oidcConfig = oidcConfig
         self.redirectUri = redirectUri
         self.socialPlugins = socialPlugins
+        self.extraParams = extraParams
     }
 
     func start() async throws -> LogtoCore.CodeTokenResponse {
@@ -54,7 +57,8 @@ class LogtoAuthSession {
                 state: state,
                 scopes: logtoConfig.scopes,
                 resources: logtoConfig.resources,
-                prompt: logtoConfig.prompt
+                prompt: logtoConfig.prompt,
+                extraParams: extraParams
             )
 
             #if !os(macOS)

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
@@ -76,7 +76,7 @@ extension LogtoClient {
      */
     public func signInWithBrowser(
         redirectUri: String,
-        extraParams: [String: String]?
+        extraParams: [String: String]
     ) async throws {
         try await signInWithBrowser(
             authSessionType: LogtoAuthSession.self,

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
@@ -12,7 +12,8 @@ import Logto
 extension LogtoClient {
     func signInWithBrowser<AuthSession: LogtoAuthSession>(
         authSessionType _: AuthSession.Type,
-        redirectUri: String
+        redirectUri: String,
+        extraParams: [String: String]? = nil
     ) async throws {
         guard let redirectUri = URL(string: redirectUri) else {
             throw (LogtoClientErrors.SignIn(type: .unableToConstructRedirectUri, innerError: nil))
@@ -24,7 +25,8 @@ extension LogtoClient {
             logtoConfig: logtoConfig,
             oidcConfig: oidcConfig,
             redirectUri: redirectUri,
-            socialPlugins: socialPlugins
+            socialPlugins: socialPlugins,
+            extraParams: extraParams
         )
 
         let response = try await session.start()
@@ -61,6 +63,25 @@ extension LogtoClient {
         try await signInWithBrowser(
             authSessionType: LogtoAuthSession.self,
             redirectUri: redirectUri
+        )
+    }
+
+    /**
+     Start a sign in session with WKWebView with additional parameters. If the function returns with no error threw, it means the user has signed in successfully.
+
+     - Parameters:
+        - redirectUri: One of Redirect URIs of this application.
+        - extraParams: Additional parameters to be passed to the authorization endpoint.
+     - Throws: An error if the session failed to complete.
+     */
+    public func signInWithBrowser(
+        redirectUri: String,
+        extraParams: [String: String]?
+    ) async throws {
+        try await signInWithBrowser(
+            authSessionType: LogtoAuthSession.self,
+            redirectUri: redirectUri,
+            extraParams: extraParams
         )
     }
 }

--- a/Tests/LogtoTests/LogtoCoreTests+Generate.swift
+++ b/Tests/LogtoTests/LogtoCoreTests+Generate.swift
@@ -160,6 +160,33 @@ extension LogtoCoreTests {
         ]))
     }
 
+    func testGenerateSignInUriWithExtraParams() throws {
+        let codeChallenge = LogtoUtilities.generateCodeChallenge(codeVerifier: codeVerifier)
+
+        let url = try LogtoCore.generateSignInUri(
+            authorizationEndpoint: authorizationEndpoint,
+            clientId: clientId,
+            redirectUri: URL(string: "logto://sign-in/redirect")!,
+            codeChallenge: codeChallenge,
+            state: state,
+            extraParams: ["tenant_id": "my_tenant", "ui_locales": "en-US"]
+        )
+        try validateBaseInformation(url: url)
+
+        XCTAssertTrue(validate(url: url, queryItems: [
+            URLQueryItem(name: "client_id", value: "foo"),
+            URLQueryItem(name: "redirect_uri", value: "logto://sign-in/redirect"),
+            URLQueryItem(name: "code_challenge", value: codeChallenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "scope", value: "offline_access openid profile"),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "prompt", value: "consent"),
+            URLQueryItem(name: "tenant_id", value: "my_tenant"),
+            URLQueryItem(name: "ui_locales", value: "en-US"),
+        ]))
+    }
+
     func testGenerateSignOutUri() throws {
         XCTAssertThrowsError(try LogtoCore
             .generateSignOutUri(endSessionEndpoint: "???", idToken: "", postLogoutRedirectUri: nil)) {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Adds extraParams parameter to the Swift SDK's sign-in flow. This enables developers to pass custom query parameters to the OIDC authorization endpoint.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- [x] successfully append extraParams to query string parameters

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] unit tests
- [x] necessary Swift comments
