### PR TITLE
fix: json value encoding and decoding

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           path: BuildTools/.build
           key: ${{ runner.os }}-spm-v1-${{ hashFiles('BuildTools/Package.resolved') }}
 
-      - run: sudo xcode-select -s /Applications/Xcode_14.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_26.1.app
 
       - name: SwiftFormat
         run: |
@@ -38,7 +38,7 @@ jobs:
           set -o pipefail && \
           xcodebuild \
             -scheme "LogtoSDK-Package" \
-            -destination "platform=iOS Simulator,OS=16.1,name=iPhone 14 Pro" \
+            -destination "platform=iOS Simulator,OS=26.1,name=iPhone 17 Pro" \
             -enableCodeCoverage=YES \
             -resultBundlePath Logto.xcresult \
             test | \

--- a/Sources/Logto/Types/Json.swift
+++ b/Sources/Logto/Types/Json.swift
@@ -13,6 +13,53 @@ public enum JsonValue: Codable, Equatable {
     case bool(Bool)
     case array([JsonValue])
     case object(JsonObject)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let v = try? container.decode(String.self) {
+            self = .string(v)
+            return
+        }
+        if let v = try? container.decode(Double.self) {
+            self = .number(v)
+            return
+        }
+        if let v = try? container.decode(Bool.self) {
+            self = .bool(v)
+            return
+        }
+        if let v = try? container.decode([JsonValue].self) {
+            self = .array(v)
+            return
+        }
+        if let v = try? container.decode(JsonObject.self) {
+            self = .object(v)
+            return
+        }
+        if container.decodeNil() {
+            self = .null
+            return
+        }
+
+        throw DecodingError.typeMismatch(
+            JsonValue.self,
+            .init(codingPath: decoder.codingPath, debugDescription: "Invalid JSON value")
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case let .string(v): try container.encode(v)
+        case let .number(v): try container.encode(v)
+        case let .bool(v): try container.encode(v)
+        case let .array(v): try container.encode(v)
+        case let .object(v): try container.encode(v)
+        case .null: try container.encodeNil()
+        }
+    }
 }
 
 public typealias JsonObject = [String: JsonValue]

--- a/Tests/LogtoMock/NetworkSessionMock.swift
+++ b/Tests/LogtoMock/NetworkSessionMock.swift
@@ -64,7 +64,8 @@ public class NetworkSessionMock: NetworkSession {
 
                 return (Data("""
                     {
-                        "sub": "foo"
+                        "sub": "foo",
+                        "custom_data": { "foo": "bar", "baz": null }
                     }
                 """.utf8), nil)
             default:

--- a/Tests/LogtoTests/LogtoCoreTests+Fetch.swift
+++ b/Tests/LogtoTests/LogtoCoreTests+Fetch.swift
@@ -64,6 +64,20 @@ extension LogtoCoreTests {
             accessToken: "good"
         )
         XCTAssertNotNil(info)
+        XCTAssertNotNil(info.sub)
+        XCTAssertNotNil(info.customData)
+        XCTAssertNotNil(info.customData?["foo"])
+
+        guard case let .string(foo) = info.customData?["foo"] else {
+            XCTFail("Expected customData[\"foo\"] to be a .string")
+            return
+        }
+        XCTAssertEqual(foo, "bar")
+
+        guard case .null = info.customData?["baz"] else {
+            XCTFail("Expected customData[\"baz\"] to be a .null")
+            return
+        }
 
         await LogtoCoreTests.assertThrows(try await LogtoCore.fetchUserInfo(
             useSession: NetworkSessionMock.shared,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix a bug in JsonValue encoding and decoding which causes error for objects with primitive property values, e.g.

```json
{ "foo": "bar" }
```

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
unit test added
