### PR TITLE
feat: add access token methods

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           set -o pipefail && \
           xcodebuild \
             -scheme "LogtoSDK-Package" \
-            -destination "platform=iOS Simulator,OS=26.1,name=iPhone 17 Pro" \
+            -destination "platform=iOS Simulator,OS=26.2,name=iPhone 17 Pro" \
             -enableCodeCoverage=YES \
             -resultBundlePath Logto.xcresult \
             test | \

--- a/Demos/SwiftUI Demo/SwiftUI Demo.xcodeproj/project.pbxproj
+++ b/Demos/SwiftUI Demo/SwiftUI Demo.xcodeproj/project.pbxproj
@@ -434,6 +434,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -466,6 +467,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
+++ b/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
@@ -9,144 +9,247 @@ import Logto
 import LogtoClient
 import SwiftUI
 
-struct ContentView: View {
-    @State var isAuthenticated: Bool
-    @State var authError: Error?
+// MARK: - 1) Edit these values
 
-    let resource = "https://api.logto.io"
-    let client: LogtoClient?
+enum DemoAuthConfig {
+    static let endpoint = "<YOUR_LOGTO_ENDPOINT>"
+    static let appId = "<YOUR_APP_ID>"
+    static let redirectUri = "<YOUR_REDIRECT_URI>" // e.g. "io.logto://callback"
+
+    // MARK: Optional config items
+
+    static let resources: [String] = [
+        "<YOUR_API_RESOURCE>", // e.g. "https://api.example.com"
+    ]
+
+    static let resourceToRequestTokenFor = "<YOUR_API_RESOURCE>"
+    static let organizationId = "<YOUR_ORGANIZATION_ID>"
+
+    static let scopes: [String] = [
+        UserScope.email.rawValue,
+        UserScope.roles.rawValue,
+        UserScope.organizations.rawValue,
+        UserScope.organizationRoles.rawValue,
+    ]
+}
+
+// MARK: - 2) ViewModel
+
+@MainActor
+final class DemoAuthViewModel: ObservableObject {
+    @Published var isAuthenticated = false
+    @Published var lastError: String?
+    @Published var output: String = ""
+
+    private let client: LogtoClient?
+    var isConfigured: Bool { client != nil }
 
     init() {
-        guard let config = try? LogtoConfig(
-            endpoint: "<your-logto-endpoint>",
-            appId: "<your-application-id>",
-            // Update per your needs
-            scopes: [
-                UserScope.email.rawValue,
-                UserScope.roles.rawValue,
-                UserScope.organizations.rawValue,
-                UserScope.organizationRoles.rawValue,
-            ],
-            // Update per your needs
-            resources: []
-        ) else {
-            client = nil
-            isAuthenticated = false
-            return
-        }
-        let logtoClient = LogtoClient(useConfig: config)
-        client = logtoClient
-        isAuthenticated = logtoClient.isAuthenticated
+        let c = Self.makeClient()
+        client = c
+        isAuthenticated = c?.isAuthenticated ?? false
 
-        if logtoClient.isAuthenticated {
-            print("authed", logtoClient.refreshToken ?? "N/A")
+        if c == nil {
+            log("config invalid: please update DemoAuthConfig placeholders")
+        } else if c?.isAuthenticated == true {
+            log("already authenticated")
         }
     }
 
-    var body: some View {
-        Text("Hello, world!")
-            .padding()
-        if isAuthenticated {
-            Text("Signed In")
-                .padding()
+    private static func makeClient() -> LogtoClient? {
+        guard let config = try? LogtoConfig(
+            endpoint: DemoAuthConfig.endpoint,
+            appId: DemoAuthConfig.appId,
+            scopes: DemoAuthConfig.scopes,
+            resources: DemoAuthConfig.resources
+        ) else {
+            return nil
         }
-        if let authError = authError {
-            Text(authError.localizedDescription)
-                .foregroundColor(.red)
-                .padding()
+        return LogtoClient(useConfig: config)
+    }
+
+    // MARK: Actions
+
+    func signIn() async {
+        guard let client else { logNotConfigured(); return }
+        clearError()
+        do {
+            try await client.signInWithBrowser(redirectUri: DemoAuthConfig.redirectUri)
+            isAuthenticated = true
+            log("sign-in success")
+        } catch {
+            isAuthenticated = false
+            handle(error, context: "sign-in")
+        }
+    }
+
+    func signOut() async {
+        guard let client else { logNotConfigured(); return }
+        clearError()
+        await client.signOut()
+        isAuthenticated = false
+        log("signed out")
+    }
+
+    func printIdTokenClaims() {
+        guard let client else { logNotConfigured(); return }
+        clearError()
+        do {
+            let claims = try client.getIdTokenClaims()
+            log("id token claims:\n\(claims)")
+        } catch {
+            handle(error, context: "get id token claims")
+        }
+    }
+
+    func fetchUserInfo() async {
+        guard let client else { logNotConfigured(); return }
+        clearError()
+        do {
+            let userInfo = try await client.fetchUserInfo()
+            log("userinfo:\n\(userInfo)")
+        } catch {
+            handle(error, context: "fetch userinfo")
+        }
+    }
+
+    func fetchAccessTokenClaims(for resource: String) async {
+        guard let client else { logNotConfigured(); return }
+        clearError()
+        do {
+            let claims = try await client.getAccessTokenClaims(for: resource)
+            log("access token claims for \(resource):\n\(claims)")
+        } catch {
+            handle(error, context: "get access token claims")
+        }
+    }
+
+    func fetchOrganizationTokenClaims(for organizationId: String) async {
+        guard let client else { logNotConfigured(); return }
+        clearError()
+        do {
+            let claims = try await client.getOrganizationTokenClaims(forId: organizationId)
+            log("organization token claims for \(organizationId):\n\(claims)")
+        } catch {
+            handle(error, context: "get organization token claims")
+        }
+    }
+
+    func fetchAccessTokenClaimsInOrg(resource: String, organizationId: String) async {
+        guard let client else { logNotConfigured(); return }
+        clearError()
+        do {
+            let claims = try await client.getAccessTokenClaims(for: resource, organizationId: organizationId)
+            log("access token claims for \(resource) in org \(organizationId):\n\(claims)")
+        } catch {
+            handle(error, context: "get access token claims in org")
+        }
+    }
+
+    // MARK: Helpers
+
+    private func clearError() {
+        lastError = nil
+    }
+
+    private func log(_ message: String) {
+        output = message
+        print(message)
+    }
+
+    private func logNotConfigured() {
+        lastError = "Logto is not configured. Please update DemoAuthConfig."
+        log(lastError!)
+    }
+
+    private func handle(_ error: Error, context: String) {
+        var msg = "[\(context)] \(error.localizedDescription)"
+
+        if let signInErr = error as? LogtoClientErrors.SignIn,
+           let resp = signInErr.innerError as? LogtoErrors.Response,
+           case let LogtoErrors.Response.withCode(_, _, data) = resp,
+           let data = data
+        {
+            msg += "\n\nresponse:\n" + String(decoding: data, as: UTF8.self)
         }
 
-        if let client = client {
-            Button("Print ID Token Claims") {
-                print(try! client.getIdTokenClaims())
-            }
-            Button("Sign In") {
-                Task { [self] in
-                    do {
-                        try await client.signInWithBrowser(redirectUri: "io.logto://callback")
-
-                        isAuthenticated = true
-                        authError = nil
-                    } catch let error as LogtoClientErrors.SignIn {
-                        isAuthenticated = false
-                        authError = error
-
-                        print("failure", error)
-
-                        if let error = error.innerError as? LogtoErrors.Response,
-                           case let LogtoErrors.Response.withCode(
-                               _,
-                               _,
-                               data
-                           ) = error, let data = data
-                        {
-                            print(String(decoding: data, as: UTF8.self))
-                        }
-                    } catch {
-                        print(error)
-                    }
-                }
-            }
-
-            Button("Sign Out") {
-                Task {
-                    await client.signOut()
-                    self.isAuthenticated = false
-                }
-            }
-
-            Button("Fetch Userinfo") {
-                Task {
-                    do {
-                        let userInfo = try await client.fetchUserInfo()
-                        print(userInfo)
-                    } catch let error as LogtoClientErrors.UserInfo {
-                        if let error = error.innerError as? LogtoClientErrors.AccessToken,
-                           let error = error.innerError as? LogtoErrors.Response,
-                           case let LogtoErrors.Response.withCode(
-                               _,
-                               _,
-                               data
-                           ) = error, let data = data
-                        {
-                            print(String(decoding: data, as: UTF8.self))
-                        } else {
-                            print(error)
-                        }
-                    } catch {
-                        print(error)
-                    }
-                }
-            }
-
-            Button("Fetch access token for \(resource)") {
-                Task {
-                    do {
-                        let token = try await client.getAccessToken(for: resource)
-                        print(token)
-                    } catch {
-                        print(error)
-                    }
-                }
-            }
-
-            Button("Fetch organization token") {
-                Task {
-                    do {
-                        // Replace `<organization-id>` with a valid organization ID
-                        let token = try await client.getOrganizationToken(forId: "<organization-id>")
-                        print(token)
-                    } catch {
-                        print(error)
-                    }
-                }
-            }
-        }
+        lastError = msg
+        log(msg)
     }
 }
 
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
+// MARK: - 3) UI
+
+struct ContentView: View {
+    @StateObject private var vm = DemoAuthViewModel()
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Status") {
+                    HStack {
+                        Text("Configured")
+                        Spacer()
+                        Text(vm.isConfigured ? "Yes" : "No")
+                            .foregroundColor(vm.isConfigured ? .green : .secondary)
+                    }
+
+                    HStack {
+                        Text("Authenticated")
+                        Spacer()
+                        Text(vm.isAuthenticated ? "Yes" : "No")
+                            .foregroundColor(vm.isAuthenticated ? .green : .secondary)
+                    }
+
+                    if let err = vm.lastError {
+                        Text(err)
+                            .foregroundColor(.red)
+                            .font(.footnote)
+                            .textSelection(.enabled)
+                    }
+                }
+
+                Section("Actions") {
+                    Button("Sign In") { Task { await vm.signIn() } }
+                        .disabled(!vm.isConfigured || vm.isAuthenticated)
+
+                    Button("Sign Out") { Task { await vm.signOut() } }
+                        .disabled(!vm.isConfigured || !vm.isAuthenticated)
+
+                    Button("Print ID Token Claims") { vm.printIdTokenClaims() }
+                        .disabled(!vm.isConfigured || !vm.isAuthenticated)
+
+                    Button("Fetch Userinfo") { Task { await vm.fetchUserInfo() } }
+                        .disabled(!vm.isConfigured || !vm.isAuthenticated)
+
+                    Button("Fetch access token claims") {
+                        Task { await vm.fetchAccessTokenClaims(for: DemoAuthConfig.resourceToRequestTokenFor) }
+                    }
+                    .disabled(!vm.isConfigured || !vm.isAuthenticated)
+
+                    Button("Fetch organization token claims") {
+                        Task { await vm.fetchOrganizationTokenClaims(for: DemoAuthConfig.organizationId) }
+                    }
+                    .disabled(!vm.isConfigured || !vm.isAuthenticated)
+
+                    Button("Fetch access token claims in organization") {
+                        Task {
+                            await vm.fetchAccessTokenClaimsInOrg(
+                                resource: DemoAuthConfig.resourceToRequestTokenFor,
+                                organizationId: DemoAuthConfig.organizationId
+                            )
+                        }
+                    }
+                    .disabled(!vm.isConfigured || !vm.isAuthenticated)
+                }
+
+                Section("Output") {
+                    Text(vm.output.isEmpty ? "(no output)" : vm.output)
+                        .font(.footnote)
+                        .textSelection(.enabled)
+                }
+            }
+            .navigationTitle("Logto SwiftUI Demo")
+        }
     }
 }

--- a/Sources/Logto/Core/LogtoCore+Fetch.swift
+++ b/Sources/Logto/Core/LogtoCore+Fetch.swift
@@ -86,6 +86,25 @@ public extension LogtoCore {
         public let expiresIn: Int64
     }
 
+    static func buildFetchTokenPayload(
+        byRefreshToken refreshToken: String,
+        clientId: String,
+        resource: String?,
+        scopes: [String]?,
+        organizationId: String?
+    ) -> [String: String?] {
+        let isResourceOrganizationUrn = LogtoUtilities.isOrganizationUrn(resource)
+        return [
+            "grant_type": TokenGrantType.refreshToken.rawValue,
+            "refresh_token": refreshToken,
+            "client_id": clientId,
+            "resource": isResourceOrganizationUrn ? nil : resource,
+            "organization_id": isResourceOrganizationUrn ? resource?
+                .suffix(from: LogtoUtilities.organizationUrnPrefix.endIndex).description : organizationId,
+            "scope": scopes?.joined(separator: " "),
+        ]
+    }
+
     /// Fetch token by `refresh_token`.
     /// Note the function will NOT validate any token in the response.
     static func fetchToken(
@@ -94,18 +113,16 @@ public extension LogtoCore {
         tokenEndpoint: String,
         clientId: String,
         resource: String?,
-        scopes: [String]?
+        scopes: [String]?,
+        organizationId: String?
     ) async throws -> RefreshTokenTokenResponse {
-        let isResourceOrganizationUrn = LogtoUtilities.isOrganizationUrn(resource)
-        let body: [String: String?] = [
-            "grant_type": TokenGrantType.refreshToken.rawValue,
-            "refresh_token": refreshToken,
-            "client_id": clientId,
-            "resource": isResourceOrganizationUrn ? nil : resource,
-            "organization_id": isResourceOrganizationUrn ? resource?
-                .suffix(from: LogtoUtilities.organizationUrnPrefix.endIndex).description : nil,
-            "scope": scopes?.joined(separator: " "),
-        ]
+        let body = buildFetchTokenPayload(
+            byRefreshToken: refreshToken,
+            clientId: clientId,
+            resource: resource,
+            scopes: scopes,
+            organizationId: organizationId
+        )
 
         return try await LogtoRequest.post(
             useSession: session,

--- a/Sources/Logto/Types/Json.swift
+++ b/Sources/Logto/Types/Json.swift
@@ -15,6 +15,36 @@ public enum JsonValue: Codable, Equatable {
     case object(JsonObject)
     case null
 
+    public var stringValue: String? {
+        guard case let .string(v) = self else { return nil }
+        return v
+    }
+
+    public var numberValue: Double? {
+        guard case let .number(v) = self else { return nil }
+        return v
+    }
+
+    public var boolValue: Bool? {
+        guard case let .bool(v) = self else { return nil }
+        return v
+    }
+
+    public var arrayValue: [JsonValue]? {
+        guard case let .array(v) = self else { return nil }
+        return v
+    }
+
+    public var objectValue: JsonObject? {
+        guard case let .object(v) = self else { return nil }
+        return v
+    }
+
+    public var isNull: Bool {
+        if case .null = self { return true }
+        return false
+    }
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 

--- a/Sources/Logto/Utilities/LogtoUtilities+AccessToken.swift
+++ b/Sources/Logto/Utilities/LogtoUtilities+AccessToken.swift
@@ -1,0 +1,29 @@
+//
+//  LogtoUtilities+AccessToken.swift
+//  LogtoSDK
+//
+//  Created by Gao Sun on 1/24/26.
+//
+
+import Foundation
+import JOSESwift
+
+public extension LogtoUtilities {
+    /// Decode Access Token claims WITHOUT validation.
+    /// - Parameter token: The JWT to decode.
+    /// - Returns: A dictionary of Access Token claims.
+    static func decodeAccessToken(_ accessToken: String) throws -> JsonObject {
+        let decoder = LogtoUtilities.getCamelCaseDecoder()
+        let segments = accessToken.split(separator: ".")
+
+        guard let payload = segments[safe: 1] else {
+            throw LogtoErrors.Decoding.noPayloadFound
+        }
+
+        guard let decoded = String.fromUrlSafeBase64(string: String(payload)) else {
+            throw LogtoErrors.Decoding.invalidUrlSafeBase64Encoding
+        }
+
+        return try decoder.decode(JsonObject.self, from: Data(decoded.utf8))
+    }
+}

--- a/Sources/Logto/Utilities/LogtoUtilities+AccessToken.swift
+++ b/Sources/Logto/Utilities/LogtoUtilities+AccessToken.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import JOSESwift
 
 public extension LogtoUtilities {
     /// Decode Access Token claims WITHOUT validation.

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
@@ -91,7 +91,7 @@ public extension LogtoClient {
     }
 
     /**
-     Get structured Access Token claims WITHOUT validation. See `getAccessToken(for:in:)` for more details.
+     Get structured Access Token claims WITHOUT validation. See `getAccessToken(for:organizationId:)` for more details.
 
      - Parameters:
         - for: The resource indicator.

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
@@ -8,13 +8,19 @@
 import Foundation
 import Logto
 
-extension LogtoClient {
-    func buildAccessTokenKey(for resource: String?) -> String {
-        resource ?? "@"
+public extension LogtoClient {
+    internal func buildAccessTokenKey(for resource: String?, in organizationId: String?) -> String {
+        guard let organizationId = organizationId else {
+            return resource ?? "@"
+        }
+
+        return (resource ?? "@") + "#" + organizationId
     }
 
-    func getAccessToken(by refreshToken: String, for resource: String?) async throws -> String {
-        let key = buildAccessTokenKey(for: resource)
+    internal func getAccessToken(by refreshToken: String, for resource: String?,
+                                 in organizationId: String?) async throws -> String
+    {
+        let key = buildAccessTokenKey(for: resource, in: organizationId)
         let oidcConfig = try await fetchOidcConfig()
 
         do {
@@ -24,7 +30,8 @@ extension LogtoClient {
                 tokenEndpoint: oidcConfig.tokenEndpoint,
                 clientId: logtoConfig.appId,
                 resource: resource,
-                scopes: nil
+                scopes: nil,
+                organizationId: organizationId
             )
 
             let accessToken = AccessToken(
@@ -51,17 +58,22 @@ extension LogtoClient {
     }
 
     /**
-     Get an Access Token for the given resource. If resource is `nil`, return the Access Token for user endpoint.
+     Get an Access Token for the given resource.
+     - If both `resource` and `organizationId` are `nil`, return the Access Token for user endpoint.
+     - If `resource` is provided but `organizationId` is `nil`, return the Access Token for the given resource.
+     - If both `resource` and `organizationId` are provided, return the Access Token for the given resource in the given organization.
+     - If `resource` is `nil` but `organizationId` is provided, an error will be thrown. Use `getOrganizationToken(forId:)` instead.
 
      If the cached Access Token has expired, this function will try to use `refreshToken` to fetch a new Access Token from the OIDC provider.
 
      - Parameters:
-        - resource: The resource indicator.
+        - for: The resource indicator.
+        - organizationId: The ID of the organization that the access token is granted for.
      - Throws: An error if failed to get a valid Access Token.
      - Returns: Access Token in string.
      */
-    @MainActor public func getAccessToken(for resource: String?) async throws -> String {
-        let key = buildAccessTokenKey(for: resource)
+    @MainActor func getAccessToken(for resource: String?, organizationId: String? = nil) async throws -> String {
+        let key = buildAccessTokenKey(for: resource, in: organizationId)
 
         // Cached access token is still valid
         if let accessToken = accessTokenMap[key], Date().timeIntervalSince1970 < accessToken.expiresAt {
@@ -73,9 +85,25 @@ extension LogtoClient {
             throw LogtoClientErrors.AccessToken(type: .noRefreshTokenFound, innerError: nil)
         }
 
-        let token = try await getAccessToken(by: refreshToken, for: resource)
+        let token = try await getAccessToken(by: refreshToken, for: resource, in: organizationId)
 
         return token
+    }
+
+    /**
+     Get structured Access Token claims WITHOUT validation. See `getAccessToken(for:in:)` for more details.
+
+     - Parameters:
+        - for: The resource indicator.
+        - organizationId: The ID of the organization that the access token is granted for.
+     - Throws: An error if failed to get a valid Access Token or decode token failed.
+     - Returns: A dictionary of Access Token claims.
+     */
+    @MainActor func getAccessTokenClaims(for resource: String?,
+                                         organizationId: String? = nil) async throws -> JsonObject
+    {
+        let accessToken = try await getAccessToken(for: resource, organizationId: organizationId)
+        return try LogtoUtilities.decodeAccessToken(accessToken)
     }
 
     /**
@@ -89,7 +117,20 @@ extension LogtoClient {
      - Throws: An error if failed to get a valid Access Token.
      - Returns: Access Token in string.
      */
-    @MainActor public func getOrganizationToken(forId id: String) async throws -> String {
+    @MainActor func getOrganizationToken(forId id: String) async throws -> String {
         try await getAccessToken(for: LogtoUtilities.buildOrganizationUrn(forId: id))
+    }
+
+    /**
+     Get structured Access Token claims for the given organization ID WITHOUT validation. See `getOrganizationToken(forId:)` for more details.
+
+     - Parameters:
+        - forId: The ID of the organization that the access token is granted for.
+     - Throws: An error if failed to get a valid Access Token or decode token failed.
+     - Returns: A dictionary of Access Token claims.
+     */
+    @MainActor func getOrganizationTokenClaims(forId id: String) async throws -> JsonObject {
+        let accessToken = try await getOrganizationToken(forId: id)
+        return try LogtoUtilities.decodeAccessToken(accessToken)
     }
 }

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
@@ -41,7 +41,7 @@ extension LogtoClient {
 
         idToken = response.idToken
         refreshToken = response.refreshToken
-        accessTokenMap[buildAccessTokenKey(for: nil)] = AccessToken(
+        accessTokenMap[buildAccessTokenKey(for: nil, in: nil)] = AccessToken(
             token: response.accessToken,
             scope: response.scope,
             expiresAt: Date().timeIntervalSince1970 + TimeInterval(response.expiresIn)

--- a/Tests/LogtoClientTests/LogtoAuthSession/LogtoWebViewAuthViewControllerTest.swift
+++ b/Tests/LogtoClientTests/LogtoAuthSession/LogtoWebViewAuthViewControllerTest.swift
@@ -89,7 +89,7 @@ final class LogtoWebViewAuthViewControllerTest: XCTestCase {
             expectation.fulfill()
         }
 
-        wait(for: [expectation], timeout: 30)
+        wait(for: [expectation], timeout: 60)
     }
 
     func testPresentationAnchor() {

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+AccessToken.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+AccessToken.swift
@@ -8,7 +8,7 @@ extension LogtoClientTests {
         let client = buildClient()
         let cachedAccessToken = "foo"
 
-        client.accessTokenMap[client.buildAccessTokenKey(for: nil)] = AccessToken(
+        client.accessTokenMap[client.buildAccessTokenKey(for: nil, in: nil)] = AccessToken(
             token: cachedAccessToken,
             scope: "",
             expiresAt: Date().timeIntervalSince1970 + 1000
@@ -23,7 +23,7 @@ extension LogtoClientTests {
         let cachedAccessToken = "foo"
 
         client
-            .accessTokenMap[client.buildAccessTokenKey(for: LogtoUtilities.buildOrganizationUrn(forId: "1"))] =
+            .accessTokenMap[client.buildAccessTokenKey(for: LogtoUtilities.buildOrganizationUrn(forId: "1"), in: nil)] =
             AccessToken(
                 token: cachedAccessToken,
                 scope: "",
@@ -39,7 +39,7 @@ extension LogtoClientTests {
 
         let client = buildClient()
         client.refreshToken = "bar"
-        client.accessTokenMap[client.buildAccessTokenKey(for: "resource1")] = AccessToken(
+        client.accessTokenMap[client.buildAccessTokenKey(for: "resource1", in: "nil")] = AccessToken(
             token: "foo",
             scope: "",
             expiresAt: Date().timeIntervalSince1970 - 1
@@ -61,7 +61,7 @@ extension LogtoClientTests {
         let client = buildClient(withOidcEndpoint: "/oidc_config:good:no_refresh")
         client.idToken = "baz"
         client.refreshToken = "bar"
-        client.accessTokenMap[client.buildAccessTokenKey(for: "resource1")] = AccessToken(
+        client.accessTokenMap[client.buildAccessTokenKey(for: "resource1", in: nil)] = AccessToken(
             token: "foo",
             scope: "",
             expiresAt: Date().timeIntervalSince1970 - 1
@@ -102,5 +102,24 @@ extension LogtoClientTests {
         }
 
         XCTFail()
+    }
+
+    func testGetOrganizationToken() async throws {
+        let client = buildClient(withOidcEndpoint: "/oidc_config:good:jwt")
+        client.refreshToken = "foo"
+
+        let token = try await client.getOrganizationToken(forId: "1")
+        XCTAssertEqual(token, NetworkSessionMock.goodAccessTokenJWT)
+    }
+
+    func testGetAccessTokenClaims() async throws {
+        let client = buildClient(withOidcEndpoint: "/oidc_config:good:jwt")
+        client.refreshToken = "foo"
+
+        let token = try await client.getAccessTokenClaims(for: "any_resource", organizationId: "any_org")
+        XCTAssertEqual(token["sub"]?.stringValue, "1234567890")
+        XCTAssertEqual(token["iss"]?.stringValue, "https://logto.dev")
+        XCTAssertEqual(token["customClaims"]?.objectValue?["role"]?.stringValue, "admin")
+        XCTAssertEqual(token["customClaims"]?.objectValue?["age"]?.numberValue, 30)
     }
 }

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+AccessToken.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+AccessToken.swift
@@ -42,15 +42,15 @@ extension LogtoClientTests {
         client.accessTokenMap[client.buildAccessTokenKey(for: "resource1", in: nil)] = AccessToken(
             token: "foo",
             scope: "",
-            expiresAt: Date().timeIntervalSince1970 - 1
+            expiresAt: Date().timeIntervalSince1970 - 1000
         )
 
-        async let get1 = client.getAccessToken(for: "resource1")
-        async let get2 = client.getAccessToken(for: "resource1")
-        let tokens = try await [get1, get2]
+        let token1 = try await client.getAccessToken(for: "resource1")
+        try await Task.sleep(nanoseconds: 1_050_000_000) // 1.05s to make token expired
+        let token2 = try await client.getAccessToken(for: "resource1")
 
-        XCTAssertEqual(tokens[0], "123")
-        XCTAssertEqual(tokens[1], "456")
+        XCTAssertEqual(token1, "123")
+        XCTAssertEqual(token2, "456")
         XCTAssertEqual(client.refreshToken, "789")
         XCTAssertEqual(client.idToken, "abc")
     }
@@ -64,7 +64,7 @@ extension LogtoClientTests {
         client.accessTokenMap[client.buildAccessTokenKey(for: "resource1", in: nil)] = AccessToken(
             token: "foo",
             scope: "",
-            expiresAt: Date().timeIntervalSince1970 - 1
+            expiresAt: Date().timeIntervalSince1970 - 1000
         )
 
         let token = try await client.getAccessToken(for: "resource1")

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+AccessToken.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+AccessToken.swift
@@ -39,7 +39,7 @@ extension LogtoClientTests {
 
         let client = buildClient()
         client.refreshToken = "bar"
-        client.accessTokenMap[client.buildAccessTokenKey(for: "resource1", in: "nil")] = AccessToken(
+        client.accessTokenMap[client.buildAccessTokenKey(for: "resource1", in: nil)] = AccessToken(
             token: "foo",
             scope: "",
             expiresAt: Date().timeIntervalSince1970 - 1

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+Fetch.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+Fetch.swift
@@ -76,7 +76,7 @@ extension LogtoClientTests {
     func testFetchUserInfoUnableToFetchUserInfo() async throws {
         let client = buildClient(withOidcEndpoint: "/oidc_config:good")
 
-        client.accessTokenMap[client.buildAccessTokenKey(for: nil)] = AccessToken(
+        client.accessTokenMap[client.buildAccessTokenKey(for: nil, in: nil)] = AccessToken(
             token: "bad",
             scope: "",
             expiresAt: Date().timeIntervalSince1970 + 1000
@@ -96,7 +96,7 @@ extension LogtoClientTests {
         let client = buildClient(withOidcEndpoint: "/oidc_config:good")
 
         client
-            .accessTokenMap[client.buildAccessTokenKey(for: nil)] = AccessToken(
+            .accessTokenMap[client.buildAccessTokenKey(for: nil, in: nil)] = AccessToken(
                 token: "good",
                 scope: "",
                 expiresAt: Date().timeIntervalSince1970 + 1000
@@ -104,5 +104,49 @@ extension LogtoClientTests {
 
         let info = try await client.fetchUserInfo()
         XCTAssertNotNil(info)
+    }
+
+    func testBuildFetchTokenPayloadByRefreshToken() {
+        let payload1 = LogtoCore.buildFetchTokenPayload(
+            byRefreshToken: "refreshToken",
+            clientId: "clientId",
+            resource: "resource",
+            scopes: ["scope1", "scope2"],
+            organizationId: "orgId"
+        )
+        XCTAssertEqual(payload1["grant_type"] as? String, "refresh_token")
+        XCTAssertEqual(payload1["refresh_token"] as? String, "refreshToken")
+        XCTAssertEqual(payload1["client_id"] as? String, "clientId")
+        XCTAssertEqual(payload1["resource"] as? String, "resource")
+        XCTAssertEqual(payload1["organization_id"] as? String, "orgId")
+        XCTAssertEqual(payload1["scope"] as? String, "scope1 scope2")
+
+        let payload2 = LogtoCore.buildFetchTokenPayload(
+            byRefreshToken: "refreshToken",
+            clientId: "clientId",
+            resource: LogtoUtilities.buildOrganizationUrn(forId: "orgId"),
+            scopes: nil,
+            organizationId: nil
+        )
+        XCTAssertEqual(payload2["grant_type"] as? String, "refresh_token")
+        XCTAssertEqual(payload2["refresh_token"] as? String, "refreshToken")
+        XCTAssertEqual(payload2["client_id"] as? String, "clientId")
+        XCTAssertNil(payload2["resource"] as? String)
+        XCTAssertEqual(payload2["organization_id"] as? String, "orgId")
+        XCTAssertNil(payload2["scope"] as? String)
+
+        let payload3 = LogtoCore.buildFetchTokenPayload(
+            byRefreshToken: "refreshToken",
+            clientId: "clientId",
+            resource: LogtoUtilities.buildOrganizationUrn(forId: "orgId"),
+            scopes: nil,
+            organizationId: "anotherOrgId"
+        )
+        XCTAssertEqual(payload3["grant_type"] as? String, "refresh_token")
+        XCTAssertEqual(payload3["refresh_token"] as? String, "refreshToken")
+        XCTAssertEqual(payload3["client_id"] as? String, "clientId")
+        XCTAssertNil(payload3["resource"] as? String)
+        XCTAssertEqual(payload3["organization_id"] as? String, "orgId")
+        XCTAssertNil(payload3["scope"] as? String)
     }
 }

--- a/Tests/LogtoMock/NetworkSessionMock.swift
+++ b/Tests/LogtoMock/NetworkSessionMock.swift
@@ -12,6 +12,8 @@ public class MockError: LocalizedError {}
 
 public class NetworkSessionMock: NetworkSession {
     public static let shared = NetworkSessionMock()
+    public static let goodAccessTokenJWT =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYXRfaGFzaCI6ImZvbyIsImF1ZCI6ImJhciIsImV4cCI6MTUxNjIzOTAyMSwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJodHRwczovL2xvZ3RvLmRldiIsImN1c3RvbUNsYWltcyI6eyJyb2xlIjoiYWRtaW4iLCJhZ2UiOjMwfX0.sJMMInlklGgbSOeOa71_uhoUvTLXDFq4jHQ1Bu81GyE"
 
     public var tokenRequestCount = 0
 
@@ -38,6 +40,18 @@ public class NetworkSessionMock: NetworkSession {
                     {
                         "authorization_endpoint": "https://logto.dev/auth:good",
                         "token_endpoint": "https://logto.dev/token:good:no_refresh",
+                        "end_session_endpoint": "https://logto.dev/end:good",
+                        "revocation_endpoint": "https://logto.dev/revoke:good",
+                        "userinfo_endpoint": "https://logto.dev/user",
+                        "jwks_uri": "https://logto.dev/jwks:good",
+                        "issuer": "http://localhost:443/oidc"
+                    }
+                """.utf8), nil)
+            case "oidc_config:good:jwt":
+                return (Data("""
+                    {
+                        "authorization_endpoint": "https://logto.dev/auth:good",
+                        "token_endpoint": "https://logto.dev/token:jwt",
                         "end_session_endpoint": "https://logto.dev/end:good",
                         "revocation_endpoint": "https://logto.dev/revoke:good",
                         "userinfo_endpoint": "https://logto.dev/user",
@@ -103,6 +117,15 @@ public class NetworkSessionMock: NetworkSession {
                 return (Data("""
                     {
                         "access_token": "123",
+                        "token_type": "jwt",
+                        "scope": "",
+                        "expires_in": 123
+                    }
+                """.utf8), nil)
+            case "token:jwt":
+                return (Data("""
+                    {
+                        "access_token": "\(NetworkSessionMock.goodAccessTokenJWT)",
                         "token_type": "jwt",
                         "scope": "",
                         "expires_in": 123

--- a/Tests/LogtoMock/NetworkSessionMock.swift
+++ b/Tests/LogtoMock/NetworkSessionMock.swift
@@ -110,7 +110,7 @@ public class NetworkSessionMock: NetworkSession {
                         "id_token": "789",
                         "token_type": "jwt",
                         "scope": "",
-                        "expires_in": 123
+                        "expires_in": 1
                     }
                 """.utf8), nil)
             case "token:good:no_refresh":

--- a/Tests/LogtoTests/LogtoCoreTests+Fetch.swift
+++ b/Tests/LogtoTests/LogtoCoreTests+Fetch.swift
@@ -43,7 +43,8 @@ extension LogtoCoreTests {
             tokenEndpoint: "/token:good",
             clientId: "foo",
             resource: "bar",
-            scopes: ["baz"]
+            scopes: ["baz"],
+            organizationId: nil
         )
         XCTAssertNotNil(token)
 
@@ -53,7 +54,8 @@ extension LogtoCoreTests {
             tokenEndpoint: "/token:bad",
             clientId: "foo",
             resource: nil,
-            scopes: []
+            scopes: [],
+            organizationId: nil
         ))
     }
 

--- a/Tests/LogtoTests/LogtoUtilitiesTests.swift
+++ b/Tests/LogtoTests/LogtoUtilitiesTests.swift
@@ -164,4 +164,104 @@ final class LogtoUtilitiesTests: XCTestCase {
             forTimeInterval: 1_642_409_648
         ))
     }
+
+    // MARK: Decode Access Token
+
+    func testDecodeAccessToken() throws {
+        XCTAssertEqual(
+            try LogtoUtilities
+                .decodeAccessToken(
+                    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYXRfaGFzaCI6ImZvbyIsImF1ZCI6ImJhciIsImV4cCI6MTUxNjIzOTAyMSwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJodHRwczovL2xvZ3RvLmRldiJ9.sJMMInlklGgbSOeOa71_uhoUvTLXDFq4jHQ1Bu81GyE"
+                ),
+            JsonObject(
+                dictionaryLiteral: (
+                    "sub",
+                    .string("1234567890")
+                ),
+                (
+                    "at_hash",
+                    .string("foo")
+                ),
+                (
+                    "aud",
+                    .string("bar")
+                ),
+                (
+                    "exp",
+                    .number(1_516_239_021)
+                ),
+                (
+                    "iat",
+                    .number(1_516_239_022)
+                ),
+                (
+                    "iss",
+                    .string("https://logto.dev")
+                ),
+                (
+                    "name",
+                    .string("John Doe")
+                )
+            )
+        )
+        XCTAssertThrowsError(try LogtoUtilities
+            .decodeAccessToken(
+                "1"
+            )) {
+                XCTAssertNotNil($0 as? LogtoErrors.Decoding)
+            }
+    }
+
+    func testDecodeAccessTokenNestedClaims() throws {
+        let accessToken =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYXRfaGFzaCI6ImZvbyIsImF1ZCI6ImJhciIsImV4cCI6MTUxNjIzOTAyMSwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJodHRwczovL2xvZ3RvLmRldiIsImN1c3RvbUNsYWltcyI6eyJyb2xlIjoiYWRtaW4iLCJhZ2UiOjMwfX0.sJMMInlklGgbSOeOa71_uhoUvTLXDFq4jHQ1Bu81GyE"
+        XCTAssertEqual(
+            try LogtoUtilities.decodeAccessToken(accessToken),
+            JsonObject(
+                dictionaryLiteral: (
+                    "sub",
+                    .string("1234567890")
+                ),
+                (
+                    "at_hash",
+                    .string("foo")
+                ),
+                (
+                    "aud",
+                    .string("bar")
+                ),
+                (
+                    "exp",
+                    .number(1_516_239_021)
+                ),
+                (
+                    "iat",
+                    .number(1_516_239_022)
+                ),
+                (
+                    "iss",
+                    .string("https://logto.dev"),
+                ),
+                (
+                    "name",
+                    .string("John Doe")
+                ),
+                (
+                    "customClaims",
+                    .object(
+                        JsonObject(
+                            dictionaryLiteral: (
+                                "role",
+                                .string("admin")
+                            ),
+                            (
+                                "age",
+                                .number(30)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

- add access token helpers to `LogtoClient` (resource + organization, plus “claims” variants)
  - `getAccessToken(for:organizationId:)`: Returns an access token for `resource` (optional) and `organizationId` (optional). Uses cached token if valid; otherwise refreshes.
  -  `getAccessTokenClaims(for:organizationId:)`: Returns decoded access token claims for `resource` and `organizationId`.
  -  `getOrganizationToken(forId:)`: Returns an organization-scoped access token for `id`.
  - `getOrganizationTokenClaims(forId:)`: Returns decoded organization token claims for `id`.
- implement underlying fetch / utilities for token exchange and parsing
- expand SwiftUI demo with placeholder-based config + buttons to fetch access/organization token claims

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test cases added/updated
