### PR TITLE
chore(deps): update dependencies and migrate to JOSESwift v3

### DIFF
--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -10,7 +10,7 @@ jobs:
   add_labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: logto-io/actions-add-labels-run-steps@v1.2.1
+      - uses: logto-io/actions-add-labels-run-steps@v1.2.2
         with:
           title: ${{ github.event.pull_request.title || github.event.issue.title }}
           github-token: ${{ github.token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
   main:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         with:
           path: |
             .build
@@ -20,8 +20,8 @@ jobs:
           key: ${{ runner.os }}-spm-v1-${{ hashFiles('Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-v1-
-      
-      - uses: actions/cache@v3
+
+      - uses: actions/cache@v5
         with:
           path: BuildTools/.build
           key: ${{ runner.os }}-spm-v1-${{ hashFiles('BuildTools/Package.resolved') }}
@@ -51,7 +51,7 @@ jobs:
           node generate-codecov-json.js --archive-path ./Logto.xcresult
 
       - name: Codecov Report Upload
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7
         with:
           flags: swift-sdk
           files: ./coverage-report-Logto.json

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/nicklockwood/SwiftFormat",
         "state": {
           "branch": null,
-          "revision": "fab94f3ca17f0f75e87787ed83b3a9423348b14c",
-          "version": "0.49.1"
+          "revision": "a5fa7a6a57abeb834df1b3fa43ea9133137d5ade",
+          "version": "0.61.1"
         }
       }
     ]

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "BuildTools",
     platforms: [.macOS(.v10_11)],
     dependencies: [
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", .exact("0.49.1")),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", .exact("0.61.1")),
     ],
     targets: [.target(name: "BuildTools", path: "")]
 )

--- a/Demos/SwiftUI Demo/SwiftUI Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demos/SwiftUI Demo/SwiftUI Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/airsidemobile/JOSESwift.git",
         "state": {
           "branch": null,
-          "revision": "10ed3b6736def7c26eb87135466b1cb46ea7e37f",
-          "version": "2.4.0"
+          "revision": "c2664a902e75c0426a1d43132bd4babc6fd173d3",
+          "version": "3.0.0"
         }
       },
       {

--- a/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
+++ b/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
@@ -42,7 +42,9 @@ final class DemoAuthViewModel: ObservableObject {
     @Published var output: String = ""
 
     private let client: LogtoClient?
-    var isConfigured: Bool { client != nil }
+    var isConfigured: Bool {
+        client != nil
+    }
 
     init() {
         let c = Self.makeClient()

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/airsidemobile/JOSESwift.git",
         "state": {
           "branch": null,
-          "revision": "10ed3b6736def7c26eb87135466b1cb46ea7e37f",
-          "version": "2.4.0"
+          "revision": "c2664a902e75c0426a1d43132bd4babc6fd173d3",
+          "version": "3.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/airsidemobile/JOSESwift.git", from: "2.4.0"),
+        .package(url: "https://github.com/airsidemobile/JOSESwift.git", from: "3.0.0"),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2"),
     ],
     targets: [

--- a/Sources/Logto/Core/LogtoCore+Fetch.swift
+++ b/Sources/Logto/Core/LogtoCore+Fetch.swift
@@ -52,7 +52,8 @@ public extension LogtoCore {
     }
 
     /// Fetch token by `authorization_code`.
-    /// The returned `access_token` is only for [UserInfo Endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo).
+    /// The returned `access_token` is only for [UserInfo
+    /// Endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo).
     /// Note the function will NOT validate any token in the response.
     static func fetchToken(
         useSession session: NetworkSession = URLSession.shared,

--- a/Sources/Logto/Extensions/URLSession.swift
+++ b/Sources/Logto/Extensions/URLSession.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension URLSession: NetworkSession {
-    internal func handleResponse(
+    func handleResponse(
         data: Data?,
         response: URLResponse?,
         error: Error?

--- a/Sources/Logto/Protocols/NetworkSession.swift
+++ b/Sources/Logto/Protocols/NetworkSession.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// https://www.swiftbysundell.com/articles/mocking-in-swift/#complete-mocking
+/// https://www.swiftbysundell.com/articles/mocking-in-swift/#complete-mocking
 public protocol NetworkSession {
     func loadData(with request: URLRequest) async -> (Data?, Error?)
 }

--- a/Sources/Logto/Types/JWT.swift
+++ b/Sources/Logto/Types/JWT.swift
@@ -1,5 +1,5 @@
 //
-//  JWK.swift
+//  JWT.swift
 //
 //
 //  Created by Gao Sun on 2022/1/10.

--- a/Sources/Logto/Types/Json.swift
+++ b/Sources/Logto/Types/Json.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Json.swift
 //
 //
 //  Created by Gao Sun on 2022/11/6.

--- a/Sources/Logto/Types/UserScope.swift
+++ b/Sources/Logto/Types/UserScope.swift
@@ -30,7 +30,8 @@ public enum UserScope: String {
     case identities
     /// The scope for user's roles for API resources. It maps to the `roles` claim.
     case roles
-    /// Scope for user's organization IDs and perform organization token grant per [RFC 0001](https://github.com/logto-io/rfcs).
+    /// Scope for user's organization IDs and perform organization token grant per [RFC
+    /// 0001](https://github.com/logto-io/rfcs).
     ///
     /// To learn more about Logto Organizations, see [Logto docs](https://docs.logto.io/docs/recipes/organizations/).
     case organizations = "urn:logto:scope:organizations"

--- a/Sources/Logto/Utilities/LogtoRequest.swift
+++ b/Sources/Logto/Utilities/LogtoRequest.swift
@@ -28,8 +28,7 @@ public enum LogtoRequest {
         }
 
         do {
-            let decoded = try decoder.decode(T.self, from: data)
-            return decoded
+            return try decoder.decode(T.self, from: data)
         } catch {
             throw error
         }
@@ -49,7 +48,7 @@ public enum LogtoRequest {
 
         request.httpMethod = method.rawValue
         request.httpBody = body
-        headers.forEach { key, value in
+        for (key, value) in headers {
             request.setValue(value, forHTTPHeaderField: key)
         }
 

--- a/Sources/Logto/Utilities/LogtoUtilities+VerifyJws.swift
+++ b/Sources/Logto/Utilities/LogtoUtilities+VerifyJws.swift
@@ -28,15 +28,15 @@ extension LogtoUtilities {
                 switch $0 {
                 case let publicKey as ECPublicKey:
                     if let secKey = try? publicKey.converted(to: SecKey.self) {
-                        return Verifier(verifyingAlgorithm: algorithm, key: secKey)
+                        return Verifier(signatureAlgorithm: algorithm, key: secKey)
                     }
                 case let publicKey as RSAPublicKey:
                     if let secKey = try? publicKey.converted(to: SecKey.self) {
-                        return Verifier(verifyingAlgorithm: algorithm, key: secKey)
+                        return Verifier(signatureAlgorithm: algorithm, key: secKey)
                     }
                 case let symmetricKey as SymmetricKey:
                     if let data = try? symmetricKey.converted(to: Data.self) {
-                        return Verifier(verifyingAlgorithm: algorithm, key: data)
+                        return Verifier(signatureAlgorithm: algorithm, key: data)
                     }
                 default:
                     throw LogtoErrors.Verification.unsupportedJwkType

--- a/Sources/LogtoClient/LogtoAuthSession/LogtoAuthSession.swift
+++ b/Sources/LogtoClient/LogtoAuthSession/LogtoAuthSession.swift
@@ -26,7 +26,7 @@ class LogtoAuthSession {
     let directSignIn: LogtoCore.DirectSignInOptions?
     let extraParams: [String: String]?
 
-    internal var callbackUri: URL?
+    var callbackUri: URL?
 
     required init(
         useSession session: NetworkSession = URLSession.shared,
@@ -111,7 +111,7 @@ class LogtoAuthSession {
                 redirectUri: redirectUri,
                 state: state
             )
-            let tokenResponse = try await LogtoCore.fetchToken(
+            return try await LogtoCore.fetchToken(
                 useSession: session,
                 byAuthorizationCode: code,
                 codeVerifier: codeVerifier,
@@ -119,7 +119,6 @@ class LogtoAuthSession {
                 clientId: logtoConfig.appId,
                 redirectUri: redirectUri.absoluteString
             )
-            return tokenResponse
         } catch let error as LogtoErrors.UriVerification {
             throw Errors.SignIn(type: .unexpectedSignInCallback, innerError: error)
         } catch {

--- a/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthSession.swift
+++ b/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthSession.swift
@@ -20,7 +20,7 @@ class LogtoWebViewAuthSession: NSObject {
     let onFinish: FinishHandler
     var viewController: LogtoWebViewAuthViewController?
 
-    public init(_ uri: URL, redirectUri: URL, socialPlugins: [LogtoSocialPlugin], onFinish: @escaping FinishHandler) {
+    init(_ uri: URL, redirectUri: URL, socialPlugins: [LogtoSocialPlugin], onFinish: @escaping FinishHandler) {
         self.uri = uri
         self.redirectUri = redirectUri
         self.socialPlugins = socialPlugins
@@ -46,7 +46,7 @@ class LogtoWebViewAuthSession: NSObject {
         }
     #endif
 
-    @discardableResult public func start() -> Bool {
+    @discardableResult func start() -> Bool {
         guard let topViewController = getTopViewController() else {
             return false
         }
@@ -61,7 +61,7 @@ class LogtoWebViewAuthSession: NSObject {
         #endif
     }
 
-    internal func didFinish(url: URL?) async {
+    func didFinish(url: URL?) async {
         guard !isFinished else {
             return
         }

--- a/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthViewController.swift
+++ b/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthViewController.swift
@@ -51,7 +51,7 @@ class LogtoWebViewAuthViewController: UnifiedViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override public func loadView() {
+    override func loadView() {
         view = UIView()
 
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -71,20 +71,20 @@ class LogtoWebViewAuthViewController: UnifiedViewController {
         view.addSubview(activityIndicator)
     }
 
-    override public func viewDidLoad() {
+    override func viewDidLoad() {
         webView.load(URLRequest(url: authSession.uri))
     }
 
-    override public func viewDidDisappear(_: Bool) {
+    override func viewDidDisappear(_: Bool) {
         Task {
             await authSession.didFinish(url: nil)
 
             // Delete related cookies asyncly when view disappeared
             if let host = authSession.uri.host {
                 WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
-                    cookies.forEach {
-                        if $0.domain == host {
-                            WKWebsiteDataStore.default().httpCookieStore.delete($0)
+                    for cooky in cookies {
+                        if cooky.domain == host {
+                            WKWebsiteDataStore.default().httpCookieStore.delete(cooky)
                         }
                     }
                 }
@@ -104,7 +104,7 @@ class LogtoWebViewAuthViewController: UnifiedViewController {
 }
 
 extension LogtoWebViewAuthViewController: ASWebAuthenticationPresentationContextProviding {
-    public func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
+    func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
         view.window!
     }
 }

--- a/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthViewController.swift
+++ b/Sources/LogtoClient/LogtoAuthSession/LogtoWebViewAuthViewController.swift
@@ -82,9 +82,9 @@ class LogtoWebViewAuthViewController: UnifiedViewController {
             // Delete related cookies asyncly when view disappeared
             if let host = authSession.uri.host {
                 WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
-                    for cooky in cookies {
-                        if cooky.domain == host {
-                            WKWebsiteDataStore.default().httpCookieStore.delete(cooky)
+                    for cookie in cookies {
+                        if cookie.domain == host {
+                            WKWebsiteDataStore.default().httpCookieStore.delete(cookie)
                         }
                     }
                 }

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+AccessToken.swift
@@ -85,9 +85,7 @@ public extension LogtoClient {
             throw LogtoClientErrors.AccessToken(type: .noRefreshTokenFound, innerError: nil)
         }
 
-        let token = try await getAccessToken(by: refreshToken, for: resource, in: organizationId)
-
-        return token
+        return try await getAccessToken(by: refreshToken, for: resource, in: organizationId)
     }
 
     /**

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
@@ -33,7 +33,7 @@ public extension LogtoClient {
                 )
                 return nil
             } catch {
-                return (LogtoClientErrors.SignOut(type: .unableToRevokeToken, innerError: error))
+                return LogtoClientErrors.SignOut(type: .unableToRevokeToken, innerError: error)
             }
         }
 

--- a/Sources/LogtoClient/LogtoClient/LogtoClient.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient.swift
@@ -39,15 +39,15 @@ public class LogtoClient {
 
     // MARK: Internal Constants
 
-    internal let authContext = LogtoAuthContext()
-    internal let keychain: Keychain?
-    internal let logtoConfig: LogtoConfig
-    internal let networkSession: NetworkSession
-    internal let socialPlugins: [LogtoSocialPlugin]
+    let authContext = LogtoAuthContext()
+    let keychain: Keychain?
+    let logtoConfig: LogtoConfig
+    let networkSession: NetworkSession
+    let socialPlugins: [LogtoSocialPlugin]
 
     // MARK: Internal Variables
 
-    internal var accessTokenMap = [String: AccessToken]()
+    var accessTokenMap = [String: AccessToken]()
 
     // MARK: Public Variables
 

--- a/Sources/LogtoClient/Types/LogtoClientErrors.swift
+++ b/Sources/LogtoClient/Types/LogtoClientErrors.swift
@@ -1,5 +1,5 @@
 //
-//  LogtoClient+Errors.swift
+//  LogtoClientErrors.swift
 //
 //
 //  Created by Gao Sun on 2022/1/30.

--- a/Sources/LogtoClient/Types/LogtoConfig.swift
+++ b/Sources/LogtoClient/Types/LogtoConfig.swift
@@ -27,7 +27,7 @@ public struct LogtoConfig {
             : _resources
     }
 
-    // Have to do this in Swift
+    /// Have to do this in Swift
     public init(
         endpoint: String,
         appId: String,

--- a/Sources/LogtoClient/Types/LogtoError.swift
+++ b/Sources/LogtoClient/Types/LogtoError.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  LogtoError.swift
 //
 //
 //  Created by Gao Sun on 2022/2/4.

--- a/Sources/LogtoClient/Types/TypeAlias.swift
+++ b/Sources/LogtoClient/Types/TypeAlias.swift
@@ -9,8 +9,10 @@ import Foundation
 
 #if !os(macOS)
     import UIKit
+
     public typealias UnifiedViewController = UIViewController
 #else
     import Cocoa
+
     public typealias UnifiedViewController = NSViewController
 #endif

--- a/Sources/LogtoSocialPlugin/LogtoSocialPlugin.swift
+++ b/Sources/LogtoSocialPlugin/LogtoSocialPlugin.swift
@@ -18,7 +18,7 @@ public struct LogtoSocialPluginConfiguration {
     public let completion: (URL) -> Void
     public let errorHandler: (LogtoSocialPluginError) -> Void
 
-    // https://stackoverflow.com/a/54673401/12514940
+    /// https://stackoverflow.com/a/54673401/12514940
     public init(
         redirectTo: URL,
         callbackUri: URL,

--- a/Sources/LogtoSocialPluginAlipay/LogtoSocialPluginAlipay.swift
+++ b/Sources/LogtoSocialPluginAlipay/LogtoSocialPluginAlipay.swift
@@ -11,7 +11,7 @@
     import Foundation
     import LogtoSocialPlugin
 
-    // Follows Alipay official docs: https://opendocs.alipay.com/open/218/wy75xo
+    /// Follows Alipay official docs: https://opendocs.alipay.com/open/218/wy75xo
     public class LogtoSocialPluginAlipay: LogtoSocialPlugin {
         public let connectorPlatform: LogtoSocialPluginPlatform = .native
         public let connectorTarget: String? = "alipay"

--- a/Sources/LogtoSocialPluginWeb/LogtoSocialPluginWeb.swift
+++ b/Sources/LogtoSocialPluginWeb/LogtoSocialPluginWeb.swift
@@ -10,7 +10,7 @@ import Foundation
 import LogtoSocialPlugin
 
 class LogtoSocialPluginWebContextProviding: NSObject, ASWebAuthenticationPresentationContextProviding {
-    public func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
+    func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
         ASPresentationAnchor()
     }
 }

--- a/Tests/LogtoClientTests/LogtoAuthSession/LogtoAuthSessionTests.swift
+++ b/Tests/LogtoClientTests/LogtoAuthSession/LogtoAuthSessionTests.swift
@@ -39,9 +39,9 @@ final class LogtoAuthSessionTests: XCTestCase {
         )
     }
 
-    // Swift cannot directly mock a class or an object unless subclassing or using generic,
-    // which increases unnecessary complecity for now.
-    // So the test case is reduced for minimum verification.
+    /// Swift cannot directly mock a class or an object unless subclassing or using generic,
+    /// which increases unnecessary complecity for now.
+    /// So the test case is reduced for minimum verification.
     func testStartOk() async throws {
         let session = createGoodSession()
         let task = Task {
@@ -54,11 +54,11 @@ final class LogtoAuthSessionTests: XCTestCase {
     }
 
     func testStartFailed() async throws {
-        let session = LogtoAuthSession(
+        let session = try LogtoAuthSession(
             useSession: NetworkSessionMock.shared,
-            logtoConfig: try! LogtoConfig(endpoint: "https://logto.dev", appId: ""),
+            logtoConfig: LogtoConfig(endpoint: "https://logto.dev", appId: ""),
             oidcConfig: getMockOidcConfig(authorizationEndpoint: "foo"),
-            redirectUri: URL(string: "foo")!,
+            redirectUri: XCTUnwrap(URL(string: "foo")),
             socialPlugins: []
         )
 
@@ -73,22 +73,22 @@ final class LogtoAuthSessionTests: XCTestCase {
     }
 
     func testHandleUnableToFetchToken() async throws {
-        let session = LogtoAuthSession(
+        let session = try LogtoAuthSession(
             useSession: NetworkSessionMock.shared,
-            logtoConfig: try! LogtoConfig(endpoint: "https://logto.dev", appId: ""),
+            logtoConfig: LogtoConfig(endpoint: "https://logto.dev", appId: ""),
             oidcConfig: getMockOidcConfig(authorizationEndpoint: "https://logto.dev/auth"),
             redirectUri: redirectUri,
             socialPlugins: []
         )
 
-        var components = URLComponents(url: redirectUri, resolvingAgainstBaseURL: true)!
+        var components = try XCTUnwrap(URLComponents(url: redirectUri, resolvingAgainstBaseURL: true))
         components.queryItems = [
             URLQueryItem(name: "state", value: session.state),
             URLQueryItem(name: "code", value: "abc"),
         ]
 
         do {
-            _ = try await session.handle(callbackUri: components.url!)
+            _ = try await session.handle(callbackUri: XCTUnwrap(components.url))
         } catch let error as LogtoClientErrors.SignIn {
             XCTAssertEqual(error.type, .unableToFetchToken)
             return
@@ -101,7 +101,7 @@ final class LogtoAuthSessionTests: XCTestCase {
         let session = createGoodSession()
 
         do {
-            _ = try await session.handle(callbackUri: URL(string: "https://foo")!)
+            _ = try await session.handle(callbackUri: XCTUnwrap(URL(string: "https://foo")))
         } catch let error as LogtoClientErrors.SignIn {
             XCTAssertEqual(error.type, .unexpectedSignInCallback)
             return
@@ -113,12 +113,12 @@ final class LogtoAuthSessionTests: XCTestCase {
     func testHandleOk() async throws {
         let session = createGoodSession()
 
-        var components = URLComponents(url: redirectUri, resolvingAgainstBaseURL: true)!
+        var components = try XCTUnwrap(URLComponents(url: redirectUri, resolvingAgainstBaseURL: true))
         components.queryItems = [
             URLQueryItem(name: "state", value: session.state),
             URLQueryItem(name: "code", value: "abc"),
         ]
 
-        _ = try await session.handle(callbackUri: components.url!)
+        _ = try await session.handle(callbackUri: XCTUnwrap(components.url))
     }
 }

--- a/Tests/LogtoClientTests/LogtoAuthSession/LogtoWebViewAuthSessionTests.swift
+++ b/Tests/LogtoClientTests/LogtoAuthSession/LogtoWebViewAuthSessionTests.swift
@@ -19,7 +19,10 @@ class LogtoWebViewAuthSessionMock: LogtoWebViewAuthSession {
 }
 
 final class WKNavigationActionMock: WKNavigationAction {
-    override var request: URLRequest { urlRequest }
+    override var request: URLRequest {
+        urlRequest
+    }
+
     let urlRequest: URLRequest
 
     init(urlRequest: URLRequest) {
@@ -84,8 +87,8 @@ final class LogtoWebViewAuthSessionTests: XCTestCase {
         await task.value
     }
 
-    func testDelegateNavigationActionCancel() async {
-        let mockUrl = URL(string: "logto://callback/path")!
+    func testDelegateNavigationActionCancel() async throws {
+        let mockUrl = try XCTUnwrap(URL(string: "logto://callback/path"))
         let session = LogtoWebViewAuthSession(mockUrl, redirectUri: mockUrl, socialPlugins: []) { _ in }
         let controller = await LogtoWebViewAuthViewController(authSession: session)
 

--- a/Tests/LogtoClientTests/LogtoAuthSession/LogtoWebViewAuthViewControllerTest.swift
+++ b/Tests/LogtoClientTests/LogtoAuthSession/LogtoWebViewAuthViewControllerTest.swift
@@ -131,7 +131,7 @@ final class LogtoWebViewAuthViewControllerTest: XCTestCase {
             ["callbackUri": mockUrl.absoluteString, "redirectTo": "mock://url"]
         ))
         XCTAssertTrue(socialPlugin.startCalled)
-        XCTAssertEqual(viewController.webView.url, URL(string: "mock://url")!)
+        XCTAssertEqual(viewController.webView.url, URL(string: "mock://url"))
     }
 
     func testUserContentControllerError() {

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+Fetch.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+Fetch.swift
@@ -15,7 +15,7 @@ extension LogtoClientTests {
 
     func testFetchOidcConfigCachedOk() async throws {
         let client = buildClient()
-        let mockConfig = try! JSONDecoder().decode(LogtoCore.OidcConfigResponse.self, from: Data("""
+        let mockConfig = try JSONDecoder().decode(LogtoCore.OidcConfigResponse.self, from: Data("""
             {
                 "authorizationEndpoint": "1",
                 "tokenEndpoint": "2",

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests.swift
@@ -45,9 +45,9 @@ final class LogtoClientTests: XCTestCase {
         return client
     }
 
-    func testStaticHandleUrl() {
+    func testStaticHandleUrl() throws {
         let appId = "foo"
-        let url = URL(string: "bar")!
+        let url = try XCTUnwrap(URL(string: "bar"))
         var called = false
 
         let handle: (Notification) -> Void = { notification in
@@ -77,7 +77,7 @@ final class LogtoClientTests: XCTestCase {
         XCTAssertTrue(client.isAuthenticated)
     }
 
-    func testGetIdTokenClaims() {
+    func testGetIdTokenClaims() throws {
         let client = buildClient()
 
         XCTAssertThrowsError(try client.getIdTokenClaims()) {
@@ -89,8 +89,8 @@ final class LogtoClientTests: XCTestCase {
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiYXVkIjoiZm9vIiwiaXNzIjoiYmFyIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE1MTYyMzkwMjJ9.t2LDedv_3AGjdOnrZuBKl83HfnD1aapuSWbPVIhwecc"
 
         XCTAssertEqual(
-            try! client.getIdTokenClaims(),
-            try! JSONDecoder().decode(IdTokenClaims.self, from: Data("""
+            try client.getIdTokenClaims(),
+            try JSONDecoder().decode(IdTokenClaims.self, from: Data("""
                 {
                     "sub": "1234567890",
                     "aud": "foo",
@@ -103,27 +103,27 @@ final class LogtoClientTests: XCTestCase {
         )
     }
 
-    func testUsingPersistStorage() {
-        let client = LogtoClient(
-            useConfig: try! LogtoConfig(endpoint: "/", appId: "foo"),
+    func testUsingPersistStorage() throws {
+        let client = try LogtoClient(
+            useConfig: LogtoConfig(endpoint: "/", appId: "foo"),
             session: NetworkSessionMock.shared
         )
 
         XCTAssertNotNil(client.keychain)
     }
 
-    func testHandleUrl() {
-        let client = LogtoClient(
-            useConfig: try! LogtoConfig(endpoint: "/", appId: "test-handle-url"),
+    func testHandleUrl() throws {
+        let client = try LogtoClient(
+            useConfig: LogtoConfig(endpoint: "/", appId: "test-handle-url"),
             socialPlugins: [LogtoSocialPluginMock()]
         )
 
-        XCTAssertTrue(client.handle(url: URL(string: "mock://foo")!))
+        XCTAssertTrue(try client.handle(url: XCTUnwrap(URL(string: "mock://foo"))))
     }
 
-    func testHandleWrongNotification() {
-        let client = LogtoClientMockHandleUrl(
-            useConfig: try! LogtoConfig(endpoint: "/", appId: "test-handle-url"),
+    func testHandleWrongNotification() throws {
+        let client = try LogtoClientMockHandleUrl(
+            useConfig: LogtoConfig(endpoint: "/", appId: "test-handle-url"),
             socialPlugins: [LogtoSocialPluginMock()]
         )
 

--- a/Tests/LogtoTests/LogtoCoreTests+Fetch.swift
+++ b/Tests/LogtoTests/LogtoCoreTests+Fetch.swift
@@ -6,13 +6,13 @@ extension LogtoCoreTests {
     func testFetchOidcConfig() async throws {
         let config = try await LogtoCore.fetchOidcConfig(
             useSession: NetworkSessionMock.shared,
-            uri: URL(string: "/oidc_config:good")!
+            uri: XCTUnwrap(URL(string: "/oidc_config:good"))
         )
         XCTAssertNotNil(config)
 
-        await LogtoCoreTests
-            .assertThrows(try await LogtoCore
-                .fetchOidcConfig(useSession: NetworkSessionMock.shared, uri: URL(string: "/bad")!))
+        try await LogtoCoreTests
+            .assertThrows(await LogtoCore
+                .fetchOidcConfig(useSession: NetworkSessionMock.shared, uri: XCTUnwrap(URL(string: "/bad"))))
     }
 
     func testFetchTokenByCode() async throws {
@@ -26,7 +26,7 @@ extension LogtoCoreTests {
         )
         XCTAssertNotNil(token)
 
-        await LogtoCoreTests.assertThrows(try await LogtoCore.fetchToken(
+        try await LogtoCoreTests.assertThrows(await LogtoCore.fetchToken(
             useSession: NetworkSessionMock.shared,
             byAuthorizationCode: "123",
             codeVerifier: "456",
@@ -48,7 +48,7 @@ extension LogtoCoreTests {
         )
         XCTAssertNotNil(token)
 
-        await LogtoCoreTests.assertThrows(try await LogtoCore.fetchToken(
+        try await LogtoCoreTests.assertThrows(await LogtoCore.fetchToken(
             useSession: NetworkSessionMock.shared,
             byRefreshToken: "123",
             tokenEndpoint: "/token:bad",
@@ -81,7 +81,7 @@ extension LogtoCoreTests {
             return
         }
 
-        await LogtoCoreTests.assertThrows(try await LogtoCore.fetchUserInfo(
+        try await LogtoCoreTests.assertThrows(await LogtoCore.fetchUserInfo(
             useSession: NetworkSessionMock.shared,
             userInfoEndpoint: "/user",
             accessToken: "bad"

--- a/Tests/LogtoTests/LogtoCoreTests+Generate.swift
+++ b/Tests/LogtoTests/LogtoCoreTests+Generate.swift
@@ -6,7 +6,7 @@ extension LogtoCoreTests {
         XCTAssertThrowsError(try LogtoCore.generateSignInUri(
             authorizationEndpoint: "???",
             clientId: "",
-            redirectUri: URL(string: "foo")!,
+            redirectUri: XCTUnwrap(URL(string: "foo")),
             codeChallenge: "",
             state: ""
         )) {
@@ -47,7 +47,7 @@ extension LogtoCoreTests {
         let url = try LogtoCore.generateSignInUri(
             authorizationEndpoint: authorizationEndpoint,
             clientId: clientId,
-            redirectUri: URL(string: "logto://sign-in/redirect")!,
+            redirectUri: XCTUnwrap(URL(string: "logto://sign-in/redirect")),
             codeChallenge: codeChallenge,
             state: state
         )
@@ -71,7 +71,7 @@ extension LogtoCoreTests {
         let url1 = try LogtoCore.generateSignInUri(
             authorizationEndpoint: authorizationEndpoint,
             clientId: clientId,
-            redirectUri: URL(string: "logto://sign-in/redirect")!,
+            redirectUri: XCTUnwrap(URL(string: "logto://sign-in/redirect")),
             codeChallenge: codeChallenge,
             state: state,
             scopes: ["foo"]
@@ -92,7 +92,7 @@ extension LogtoCoreTests {
         let url2 = try LogtoCore.generateSignInUri(
             authorizationEndpoint: authorizationEndpoint,
             clientId: clientId,
-            redirectUri: URL(string: "logto://sign-in/redirect")!,
+            redirectUri: XCTUnwrap(URL(string: "logto://sign-in/redirect")),
             codeChallenge: codeChallenge,
             state: state,
             scopes: ["foo", "bar"]
@@ -117,7 +117,7 @@ extension LogtoCoreTests {
         let url1 = try LogtoCore.generateSignInUri(
             authorizationEndpoint: authorizationEndpoint,
             clientId: clientId,
-            redirectUri: URL(string: "logto://sign-in/redirect")!,
+            redirectUri: XCTUnwrap(URL(string: "logto://sign-in/redirect")),
             codeChallenge: codeChallenge,
             state: state,
             resources: ["https://api.logto.dev"]
@@ -139,7 +139,7 @@ extension LogtoCoreTests {
         let url2 = try LogtoCore.generateSignInUri(
             authorizationEndpoint: authorizationEndpoint,
             clientId: clientId,
-            redirectUri: URL(string: "logto://sign-in/redirect")!,
+            redirectUri: XCTUnwrap(URL(string: "logto://sign-in/redirect")),
             codeChallenge: codeChallenge,
             state: state,
             resources: ["https://api.logto.dev", "bar"]
@@ -166,7 +166,7 @@ extension LogtoCoreTests {
         let url = try LogtoCore.generateSignInUri(
             authorizationEndpoint: authorizationEndpoint,
             clientId: clientId,
-            redirectUri: URL(string: "logto://sign-in/redirect")!,
+            redirectUri: XCTUnwrap(URL(string: "logto://sign-in/redirect")),
             codeChallenge: codeChallenge,
             state: state,
             loginHint: "foo@logto.dev",
@@ -196,12 +196,13 @@ extension LogtoCoreTests {
 
     func testGenerateSignOutUri() throws {
         XCTAssertThrowsError(try LogtoCore
-            .generateSignOutUri(endSessionEndpoint: "???", idToken: "", postLogoutRedirectUri: nil)) {
-                XCTAssertEqual(
-                    $0 as? LogtoErrors.UrlConstruction,
-                    LogtoErrors.UrlConstruction.invalidEndpoint
-                )
-            }
+            .generateSignOutUri(endSessionEndpoint: "???", idToken: "", postLogoutRedirectUri: nil))
+        {
+            XCTAssertEqual(
+                $0 as? LogtoErrors.UrlConstruction,
+                LogtoErrors.UrlConstruction.invalidEndpoint
+            )
+        }
 
         let endSessionEndpoint = "https://logto.dev/oidc/session/end"
         let idToken = "foo"

--- a/Tests/LogtoTests/LogtoCoreTests+Revoke.swift
+++ b/Tests/LogtoTests/LogtoCoreTests+Revoke.swift
@@ -11,7 +11,7 @@ extension LogtoCoreTests {
             clientId: "foo"
         )
 
-        await LogtoCoreTests.assertThrows(try await LogtoCore.revoke(
+        try await LogtoCoreTests.assertThrows(await LogtoCore.revoke(
             useSession: NetworkSessionMock.shared,
             token: "123",
             revocationEndpoint: "/revoke:bad",

--- a/Tests/LogtoTests/LogtoCoreTests+Verify.swift
+++ b/Tests/LogtoTests/LogtoCoreTests+Verify.swift
@@ -5,14 +5,15 @@ extension LogtoCoreTests {
     func testVerifyAndParseSignInCallbackUri() throws {
         let state = "123"
         let code = "456"
-        let callbackUri = URL(string: "logto-dev://callback?state=\(state)&code=\(code)")!
-        let callbackUriWithError = URL(string: "logto-dev://callback?state=\(state)&code=\(code)&error=foo")!
-        let callbackUriWithNoCode = URL(string: "logto-dev://callback?state=\(state)")!
-        let redirectUri = URL(string: "logto-dev://callback")!
+        let callbackUri = try XCTUnwrap(URL(string: "logto-dev://callback?state=\(state)&code=\(code)"))
+        let callbackUriWithError =
+            try XCTUnwrap(URL(string: "logto-dev://callback?state=\(state)&code=\(code)&error=foo"))
+        let callbackUriWithNoCode = try XCTUnwrap(URL(string: "logto-dev://callback?state=\(state)"))
+        let redirectUri = try XCTUnwrap(URL(string: "logto-dev://callback"))
 
         XCTAssertThrowsError(try LogtoCore
             .verifyAndParseSignInCallbackUri(
-                URL(string: "aaa")!,
+                XCTUnwrap(URL(string: "aaa")),
                 redirectUri: redirectUri,
                 state: state
             )) {
@@ -20,22 +21,25 @@ extension LogtoCoreTests {
             }
 
         XCTAssertThrowsError(try LogtoCore
-            .verifyAndParseSignInCallbackUri(redirectUri, redirectUri: redirectUri, state: state)) {
-                XCTAssertEqual($0 as? LogtoErrors.UriVerification, LogtoErrors.UriVerification.stateMismatched)
-            }
+            .verifyAndParseSignInCallbackUri(redirectUri, redirectUri: redirectUri, state: state))
+        {
+            XCTAssertEqual($0 as? LogtoErrors.UriVerification, LogtoErrors.UriVerification.stateMismatched)
+        }
 
         XCTAssertThrowsError(try LogtoCore
-            .verifyAndParseSignInCallbackUri(callbackUriWithError, redirectUri: redirectUri, state: state)) {
-                XCTAssertEqual(
-                    $0 as? LogtoErrors.UriVerification,
-                    LogtoErrors.UriVerification.errorItemFound(items: [URLQueryItem(name: "error", value: "foo")])
-                )
-            }
+            .verifyAndParseSignInCallbackUri(callbackUriWithError, redirectUri: redirectUri, state: state))
+        {
+            XCTAssertEqual(
+                $0 as? LogtoErrors.UriVerification,
+                LogtoErrors.UriVerification.errorItemFound(items: [URLQueryItem(name: "error", value: "foo")])
+            )
+        }
 
         XCTAssertThrowsError(try LogtoCore
-            .verifyAndParseSignInCallbackUri(callbackUriWithNoCode, redirectUri: redirectUri, state: state)) {
-                XCTAssertEqual($0 as? LogtoErrors.UriVerification, LogtoErrors.UriVerification.missingCode)
-            }
+            .verifyAndParseSignInCallbackUri(callbackUriWithNoCode, redirectUri: redirectUri, state: state))
+        {
+            XCTAssertEqual($0 as? LogtoErrors.UriVerification, LogtoErrors.UriVerification.missingCode)
+        }
 
         XCTAssertEqual(
             try LogtoCore.verifyAndParseSignInCallbackUri(callbackUri, redirectUri: redirectUri, state: state),

--- a/Tests/LogtoTests/LogtoUtilitiesTests.swift
+++ b/Tests/LogtoTests/LogtoUtilitiesTests.swift
@@ -3,7 +3,7 @@ import JOSESwift
 import XCTest
 
 final class LogtoUtilitiesTests: XCTestCase {
-    func testWithReservedScopes() throws {
+    func testWithReservedScopes() {
         XCTAssertEqual(LogtoUtilities.withReservedScopes([]).sorted(), ["offline_access", "openid", "profile"].sorted())
         XCTAssertEqual(
             LogtoUtilities.withReservedScopes(["foo"]).sorted(),
@@ -15,19 +15,19 @@ final class LogtoUtilitiesTests: XCTestCase {
         )
     }
 
-    func testGenerateState() throws {
+    func testGenerateState() {
         let state = LogtoUtilities.generateState()
         XCTAssertTrue(state.isUrlSafe)
         XCTAssertEqual(Data.fromUrlSafeBase64(string: state)?.count, 64)
     }
 
-    func testGenerateCodeVerifier() throws {
+    func testGenerateCodeVerifier() {
         let verifier = LogtoUtilities.generateCodeVerifier()
         XCTAssertTrue(verifier.isUrlSafe)
         XCTAssertEqual(Data.fromUrlSafeBase64(string: verifier)?.count, 64)
     }
 
-    func testGenerateCodeChallenge() throws {
+    func testGenerateCodeChallenge() {
         XCTAssertEqual(
             LogtoUtilities
                 .generateCodeChallenge(
@@ -99,9 +99,10 @@ final class LogtoUtilitiesTests: XCTestCase {
         let clientId = "foo"
 
         XCTAssertThrowsError(try LogtoUtilities
-            .verifyIdToken(idToken, issuer: "foo", clientId: "bar", jwks: JWKSet(keys: []))) {
-                XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.missingJwk)
-            }
+            .verifyIdToken(idToken, issuer: "foo", clientId: "bar", jwks: JWKSet(keys: [])))
+        {
+            XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.missingJwk)
+        }
         XCTAssertThrowsError(try LogtoUtilities.verifyIdToken(idToken, issuer: "foo", clientId: "bar", jwks: jwks2)) {
             XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.noSigningKeyMatched)
         }
@@ -124,9 +125,10 @@ final class LogtoUtilitiesTests: XCTestCase {
             XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.jwtExpired)
         }
         XCTAssertThrowsError(try LogtoUtilities
-            .verifyIdToken(idToken, issuer: issuer, clientId: clientId, jwks: jwks, forTimeInterval: 0)) {
-                XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.jwtIssuedTimeIncorrect)
-            }
+            .verifyIdToken(idToken, issuer: issuer, clientId: clientId, jwks: jwks, forTimeInterval: 0))
+        {
+            XCTAssertEqual($0 as? LogtoErrors.Verification, LogtoErrors.Verification.jwtIssuedTimeIncorrect)
+        }
     }
 
     func testVerifyIdTokenRSA() throws {
@@ -240,7 +242,7 @@ final class LogtoUtilitiesTests: XCTestCase {
                 ),
                 (
                     "iss",
-                    .string("https://logto.dev"),
+                    .string("https://logto.dev")
                 ),
                 (
                     "name",

--- a/Tests/LogtoTests/URLSessionTests.swift
+++ b/Tests/LogtoTests/URLSessionTests.swift
@@ -10,10 +10,10 @@ import Foundation
 import XCTest
 
 final class URLSessionTests: XCTestCase {
-    func testHandleResponseOk() {
+    func testHandleResponseOk() throws {
         let mockData = "123".data(using: .utf8)!
-        let response = HTTPURLResponse(
-            url: URL(string: "https://logto.dev")!,
+        let response = try HTTPURLResponse(
+            url: XCTUnwrap(URL(string: "https://logto.dev")),
             statusCode: 200,
             httpVersion: nil,
             headerFields: nil
@@ -25,10 +25,10 @@ final class URLSessionTests: XCTestCase {
         XCTAssertNil(error)
     }
 
-    func testHandleResponseStatusCodeError() {
+    func testHandleResponseStatusCodeError() throws {
         let mockData = "123".data(using: .utf8)!
-        let response = HTTPURLResponse(
-            url: URL(string: "https://logto.dev")!,
+        let response = try HTTPURLResponse(
+            url: XCTUnwrap(URL(string: "https://logto.dev")),
             statusCode: 400,
             httpVersion: nil,
             headerFields: nil


### PR DESCRIPTION
## Summary

Consolidated dependency updates, superseding the open Renovate PRs so the upcoming feature work starts from an up-to-date base.

**Runtime dependency**
- `airsidemobile/JOSESwift` `2.4.0` → `3.0.0` (major). The only required source change is the verifier init label rename introduced in JOSESwift 3.0.0 (`verifyingAlgorithm:` → `signatureAlgorithm:`) in `LogtoUtilities+VerifyJws.swift`. All other APIs in use (`validate(using:)`, `converted(to:)`, `JWKSet`, `ECPublicKey`/`RSAPublicKey`/`SymmetricKey`, `JWS`, `SignatureAlgorithm`) remain compatible. Refreshed `Package.resolved` for the SDK and the SwiftUI demo. (supersedes #135)

**Build tooling**
- `nicklockwood/SwiftFormat` `0.49.1` → `0.61.1`. The codebase was reformatted to satisfy the new default rules so `swiftformat --lint` passes. See "Source changes from the SwiftFormat upgrade" below for what changed beyond whitespace. (supersedes #134)

**GitHub Actions**
- `actions/checkout` `v4` → `v6` (supersedes #141)
- `actions/cache` `v3` → `v5` (supersedes #143)
- `codecov/codecov-action` `v3` → `v7` (supersedes #148)
- `logto-io/actions-add-labels-run-steps` `v1.2.1` → `v1.2.2` (supersedes #138)

## Source changes from the SwiftFormat upgrade

Most of the reformat is whitespace/wrapping. A few new rules made non-whitespace edits worth calling out:

### Access modifiers (`redundantInternal`, `redundantPublic`) — no API change

A number of `public` and `internal` modifiers were removed. **None of these change the public API surface** — every removed modifier was a no-op:

- **`redundantInternal`** — dropped explicit `internal` keywords. `internal` is Swift's default access level, so writing it or not is identical. E.g. `LogtoClient`'s `internal let keychain` → `let keychain` (still internal), and `URLSession.handleResponse`, `LogtoAuthSession.callbackUri`, etc.
- **`redundantPublic`** — dropped `public` from members of **internal types**. Swift caps a member's effective access at its enclosing type's access level, so `public` on a member of an internal type is unreachable outside the module and has no effect. The affected declarations all live in internal types:
  - `LogtoWebViewAuthSession` (internal `class`) — `init`, `start()`
  - `LogtoWebViewAuthViewController` (internal `class`) — `loadView` / `viewDidLoad` / `viewDidDisappear` / `presentationAnchor`
  - `LogtoAuthContext` (internal `class`) — `presentationAnchor`

No `public` was removed from any public type (`LogtoClient`, `LogtoConfig`, `LogtoError`, the `public extension LogtoClient` APIs, etc. are untouched). Verified: `LogtoClient` still declares the same set of `public` members before and after.

### Other behavioral rules (semantically equivalent)

- **`preferForLoop`** — `array.forEach { ... }` → `for x in array { ... }` (e.g. cookie cleanup in `LogtoWebViewAuthViewController`, header setup in `LogtoRequest`).
- **`redundantVariable`** — `let x = expr; return x` → `return expr`.
- **`hoistTry`** — moved inline `try` to the start of the expression.
- **`noForceUnwrapInTests`** — in tests only, `URL(string:)!` → `XCTUnwrap(URL(string:))` (covered by the surrounding `try`).

## Testing

tested locally — `swiftformat --lint` clean (0/68) and `xcodebuild test` green (73 tests, 0 failures) on the iOS Simulator.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments