### PR TITLE
fix: prevent concurrent sign-in sessions

### DIFF
--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
@@ -10,6 +10,7 @@ import Foundation
 import Logto
 
 extension LogtoClient {
+    @MainActor
     func signInWithBrowser<AuthSession: LogtoAuthSession>(
         authSessionType _: AuthSession.Type,
         redirectUri: String,
@@ -19,6 +20,15 @@ extension LogtoClient {
     ) async throws {
         guard let redirectUri = URL(string: redirectUri) else {
             throw (LogtoClientErrors.SignIn(type: .unableToConstructRedirectUri, innerError: nil))
+        }
+
+        guard !isSigningIn else {
+            throw LogtoClientErrors.SignIn(type: .signInSessionAlreadyInProgress, innerError: nil)
+        }
+
+        isSigningIn = true
+        defer {
+            isSigningIn = false
         }
 
         let oidcConfig = try await fetchOidcConfig()
@@ -64,6 +74,7 @@ extension LogtoClient {
         - extraParams: Extra parameters for the authentication request.
      - Throws: An error if the session failed to complete.
      */
+    @MainActor
     public func signInWithBrowser(
         redirectUri: String,
         loginHint: String? = nil,

--- a/Sources/LogtoClient/LogtoClient/LogtoClient.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient.swift
@@ -48,6 +48,7 @@ public class LogtoClient {
     // MARK: Internal Variables
 
     var accessTokenMap = [String: AccessToken]()
+    var isSigningIn = false
 
     // MARK: Public Variables
 

--- a/Sources/LogtoClient/Types/LogtoClientErrorTypes.swift
+++ b/Sources/LogtoClient/Types/LogtoClientErrorTypes.swift
@@ -36,6 +36,8 @@ public enum LogtoClientErrorTypes {
         /// Failed to complete the authentication.
         /// This could be an internal error or the user canceled the authentication.
         case authFailed
+        /// A sign-in session is already in progress.
+        case signInSessionAlreadyInProgress
         /// Unable to construct Redirect URI for the given string.
         case unableToConstructRedirectUri
         /// Unable to construct Redirect URI for the config.

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignIn.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignIn.swift
@@ -65,6 +65,25 @@ class LogtoAuthSessionCaptureMock: LogtoAuthSession {
     }
 }
 
+class LogtoAuthSessionBlockingMock: LogtoAuthSession {
+    static var didStart: XCTestExpectation?
+    static var release: CheckedContinuation<Void, Never>?
+
+    static func reset() {
+        didStart = nil
+        release = nil
+    }
+
+    override func start() async throws -> LogtoCore.CodeTokenResponse {
+        await withCheckedContinuation {
+            Self.release = $0
+            Self.didStart?.fulfill()
+        }
+
+        throw LogtoAuthSession.Errors.SignIn(type: .unknownError, innerError: nil)
+    }
+}
+
 extension LogtoClientTests {
     func testSignInUnableToFetchJwkSet() async throws {
         let client = buildClient(withToken: true)
@@ -133,6 +152,45 @@ extension LogtoClientTests {
         }
 
         XCTFail()
+    }
+
+    func testSignInRejectsConcurrentSession() async throws {
+        LogtoAuthSessionBlockingMock.reset()
+
+        let client = buildClient()
+        let didStart = expectation(description: "first sign-in started")
+        LogtoAuthSessionBlockingMock.didStart = didStart
+
+        let firstSignIn = Task {
+            try await client.signInWithBrowser(
+                authSessionType: LogtoAuthSessionBlockingMock.self,
+                redirectUri: "io.logto.dev://callback"
+            )
+        }
+
+        await fulfillment(of: [didStart], timeout: 1)
+
+        let secondSignInError: Error?
+        do {
+            try await client.signInWithBrowser(
+                authSessionType: LogtoAuthSessionFailureMock.self,
+                redirectUri: "io.logto.dev://callback"
+            )
+            secondSignInError = nil
+        } catch {
+            secondSignInError = error
+        }
+
+        LogtoAuthSessionBlockingMock.release?.resume()
+        LogtoAuthSessionBlockingMock.release = nil
+        _ = try? await firstSignIn.value
+
+        guard let error = secondSignInError as? LogtoClientErrors.SignIn else {
+            XCTFail("Expected SignIn error")
+            return
+        }
+
+        XCTAssertEqual(error.type, .signInSessionAlreadyInProgress)
     }
 
     func testSignInUnknownError() async throws {


### PR DESCRIPTION
## Summary
- isolate browser sign-in on `@MainActor` so token state updates share the same actor model as access token APIs
- prevent concurrent `signInWithBrowser` calls by rejecting a second active session with `signInSessionAlreadyInProgress`
- add a regression test for repeated sign-in attempts

## Tests
- `xcodebuild test -scheme LogtoSDK-Package -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.3.1'`\n- `swift run -c release swiftformat ../ --lint` (from `BuildTools`)\n\nNote: `swift test` still fails on macOS before reaching these tests because the existing WebView auth files compile UIKit-only APIs for the macOS target.