### PR TITLE
feat: add iOS browser sign-out support

### DIFF
--- a/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
+++ b/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
@@ -14,7 +14,8 @@ import SwiftUI
 enum DemoAuthConfig {
     static let endpoint = "<YOUR_LOGTO_ENDPOINT>"
     static let appId = "<YOUR_APP_ID>"
-    static let redirectUri = "<YOUR_REDIRECT_URI>" // e.g. "io.logto://callback"
+    static let redirectUri = "logto-demo://callback"
+    static let postLogoutRedirectUri = "logto-demo://signed-out"
 
     // MARK: Optional config items
 
@@ -88,9 +89,22 @@ final class DemoAuthViewModel: ObservableObject {
     func signOut() async {
         guard let client else { logNotConfigured(); return }
         clearError()
-        await client.signOut()
-        isAuthenticated = false
-        log("signed out")
+        let error = await client.signOut(postLogoutRedirectUri: DemoAuthConfig.postLogoutRedirectUri)
+        handleSignOutResult(error, context: "sign-out", successMessage: "signed out with redirect")
+    }
+
+    func signOutWithoutRedirect() async {
+        guard let client else { logNotConfigured(); return }
+        clearError()
+        let error = await client.signOut()
+        handleSignOutResult(error, context: "sign-out without redirect", successMessage: "signed out without redirect")
+    }
+
+    func clearCredentials() async {
+        guard let client else { logNotConfigured(); return }
+        clearError()
+        let error = await client.clearCredentials()
+        handleSignOutResult(error, context: "clear credentials", successMessage: "credentials cleared")
     }
 
     func printIdTokenClaims() {
@@ -164,6 +178,34 @@ final class DemoAuthViewModel: ObservableObject {
         log(lastError!)
     }
 
+    private func handleSignOutResult(
+        _ error: LogtoClientErrors.SignOut?,
+        context: String,
+        successMessage: String
+    ) {
+        isAuthenticated = client?.isAuthenticated ?? false
+
+        if let error {
+            handleSignOut(error, context: context)
+            return
+        }
+
+        log(successMessage)
+    }
+
+    private func handleSignOut(_ error: LogtoClientErrors.SignOut, context: String) {
+        var msg = "[\(context)] \(error.type.rawValue)"
+
+        if let innerError = error.innerError {
+            let nsError = innerError as NSError
+            msg += "\ninner: \(innerError.localizedDescription)"
+            msg += "\ninner domain: \(nsError.domain), code: \(nsError.code)"
+        }
+
+        lastError = msg
+        log(msg)
+    }
+
     private func handle(_ error: Error, context: String) {
         var msg = "[\(context)] \(error.localizedDescription)"
 
@@ -216,6 +258,12 @@ struct ContentView: View {
                         .disabled(!vm.isConfigured || vm.isAuthenticated)
 
                     Button("Sign Out") { Task { await vm.signOut() } }
+                        .disabled(!vm.isConfigured || !vm.isAuthenticated)
+
+                    Button("Sign Out Without Redirect") { Task { await vm.signOutWithoutRedirect() } }
+                        .disabled(!vm.isConfigured || !vm.isAuthenticated)
+
+                    Button("Clear Credentials") { Task { await vm.clearCredentials() } }
                         .disabled(!vm.isConfigured || !vm.isAuthenticated)
 
                     Button("Print ID Token Claims") { vm.printIdTokenClaims() }

--- a/Sources/Logto/Core/LogtoCore+Generate.swift
+++ b/Sources/Logto/Core/LogtoCore+Generate.swift
@@ -100,8 +100,8 @@ public extension LogtoCore {
 
     static func generateSignOutUri(
         endSessionEndpoint: String,
-        idToken: String,
-        postLogoutRedirectUri: String?
+        clientId: String,
+        postLogoutRedirectUri: String? = nil
     ) throws -> URL {
         guard
             var components = URLComponents(string: endSessionEndpoint),
@@ -112,10 +112,16 @@ public extension LogtoCore {
         }
 
         let queryItems = [
-            URLQueryItem(name: "id_token_hint", value: idToken),
+            URLQueryItem(name: "client_id", value: clientId),
             URLQueryItem(name: "post_logout_redirect_uri", value: postLogoutRedirectUri),
         ]
-        components.queryItems = queryItems.filter { $0.value != "" }
+        components.queryItems = queryItems.filter {
+            guard let value = $0.value else {
+                return false
+            }
+
+            return !value.isEmpty
+        }
 
         guard let url = components.url else {
             throw LogtoErrors.UrlConstruction.unableToConstructUrl

--- a/Sources/LogtoClient/LogtoAuthSession/LogtoASWebAuthenticationSession.swift
+++ b/Sources/LogtoClient/LogtoAuthSession/LogtoASWebAuthenticationSession.swift
@@ -121,7 +121,7 @@
             return try await startAuthenticationSession(with: authUri)
         }
 
-        private static func createAuthenticationSession(
+        static func createAuthenticationSession(
             url: URL,
             callbackURLScheme: String?,
             completionHandler: @escaping CompletionHandler
@@ -133,12 +133,16 @@
             )
         }
 
-        private var callbackURLScheme: String? {
-            guard let scheme = redirectUri.scheme?.lowercased(), !["http", "https"].contains(scheme) else {
+        static func callbackURLScheme(for url: URL) -> String? {
+            guard let scheme = url.scheme?.lowercased(), !["http", "https"].contains(scheme) else {
                 return nil
             }
 
             return scheme
+        }
+
+        private var callbackURLScheme: String? {
+            Self.callbackURLScheme(for: redirectUri)
         }
 
         private func startAuthenticationSession(with authUri: URL) async throws -> LogtoCore.CodeTokenResponse {

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
@@ -97,6 +97,7 @@ extension LogtoClient {
 
 #if os(iOS)
     private struct LogtoSignOutSessionError: Error {}
+    private struct LogtoUnexpectedSignOutCallbackError: Error {}
 
     private final class LogtoSignOutSessionContinuation {
         private let continuation: CheckedContinuation<Void, Error>
@@ -181,6 +182,8 @@ extension LogtoClient {
                 )
             } catch let error as LogtoErrors.UrlConstruction {
                 return LogtoClientErrors.SignOut(type: .unableToConstructSignOutUri, innerError: error)
+            } catch let error as LogtoUnexpectedSignOutCallbackError {
+                return LogtoClientErrors.SignOut(type: .unexpectedSignOutCallback, innerError: error)
             } catch {
                 return LogtoClientErrors.SignOut(type: .unableToLaunchBrowser, innerError: error)
             }
@@ -224,7 +227,7 @@ extension LogtoClient {
                     }
 
                     guard Self.isCallbackUri(callbackUri, matching: postLogoutRedirectUri) else {
-                        resolver.resume(throwing: LogtoSignOutSessionError())
+                        resolver.resume(throwing: LogtoUnexpectedSignOutCallbackError())
                         return
                     }
 

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
@@ -5,6 +5,9 @@
 //  Created by Gao Sun on 2022/2/4.
 //
 
+#if os(iOS)
+    import AuthenticationServices
+#endif
 import Foundation
 import Logto
 
@@ -12,31 +15,265 @@ public extension LogtoClient {
     /**
      Clear all tokens in memory and Keychain. Also try to revoke the Refresh Token from the OIDC provider.
 
-     - Returns: An error if failed to revoke the token. Usually the error is safe to ignore.
+     - Returns: An error if failed to clear or revoke the token. Usually the token revocation error is safe to ignore.
      */
     @discardableResult
-    func signOut() async -> LogtoClientErrors.SignOut? {
+    func clearCredentials() async -> LogtoClientErrors.SignOut? {
+        guard isAuthenticated else {
+            return LogtoClientErrors.SignOut(type: .notAuthenticated, innerError: nil)
+        }
+
+        let tokenToRevoke = clearLocalCredentials()
+
+        guard let token = tokenToRevoke else {
+            return nil
+        }
+
+        let oidcConfig: LogtoCore.OidcConfigResponse
+
+        do {
+            oidcConfig = try await fetchOidcConfig()
+        } catch {
+            return LogtoClientErrors.SignOut(type: .unableToFetchOidcConfig, innerError: error)
+        }
+
+        do {
+            try await revokeRefreshToken(token, revocationEndpoint: oidcConfig.revocationEndpoint)
+            return nil
+        } catch {
+            return LogtoClientErrors.SignOut(type: .unableToRevokeToken, innerError: error)
+        }
+    }
+
+    #if os(iOS)
+        /**
+         Sign out from Logto in the browser and clear all local credentials.
+
+         - Parameter postLogoutRedirectUri: One of Post sign-out redirect URIs of this application. When omitted, the browser stays on the Logto sign-out page and the user can dismiss it manually.
+         - Returns: An error if the browser sign-out or token revocation failed.
+         */
+        @MainActor
+        @discardableResult
+        func signOut(postLogoutRedirectUri: String? = nil) async -> LogtoClientErrors.SignOut? {
+            await signOut(
+                postLogoutRedirectUri: postLogoutRedirectUri,
+                authenticationSessionFactory: LogtoASWebAuthenticationSession.createAuthenticationSession
+            )
+        }
+    #else
+        @available(
+            *,
+            unavailable,
+            message: "Browser sign-out is currently available on iOS only. Use clearCredentials() to clear local credentials."
+        )
+        @discardableResult
+        func signOut(postLogoutRedirectUri _: String? = nil) async -> LogtoClientErrors.SignOut? {
+            fatalError("Browser sign-out is currently available on iOS only.")
+        }
+    #endif
+}
+
+extension LogtoClient {
+    @discardableResult
+    func clearLocalCredentials() -> String? {
         let tokenToRevoke = refreshToken
 
         accessTokenMap = [:]
         refreshToken = nil
         idToken = nil
 
-        if let token = tokenToRevoke {
+        return tokenToRevoke
+    }
+
+    func revokeRefreshToken(_ token: String, revocationEndpoint: String) async throws {
+        try await LogtoCore.revoke(
+            useSession: networkSession,
+            token: token,
+            revocationEndpoint: revocationEndpoint,
+            clientId: logtoConfig.appId
+        )
+    }
+}
+
+#if os(iOS)
+    private struct LogtoSignOutSessionError: Error {}
+
+    private final class LogtoSignOutSessionContinuation {
+        private let continuation: CheckedContinuation<Void, Error>
+        private let lock = NSLock()
+        private var isResolved = false
+
+        init(_ continuation: CheckedContinuation<Void, Error>) {
+            self.continuation = continuation
+        }
+
+        func resume() {
+            lock.lock()
+            defer { lock.unlock() }
+
+            guard !isResolved else {
+                return
+            }
+
+            isResolved = true
+            continuation.resume()
+        }
+
+        func resume(throwing error: Error) {
+            lock.lock()
+            defer { lock.unlock() }
+
+            guard !isResolved else {
+                return
+            }
+
+            isResolved = true
+            continuation.resume(throwing: error)
+        }
+    }
+
+    extension LogtoClient {
+        @MainActor
+        @discardableResult
+        func signOut(
+            postLogoutRedirectUri: String? = nil,
+            authenticationSessionFactory: @escaping LogtoASWebAuthenticationSession.AuthenticationSessionFactory
+        ) async -> LogtoClientErrors.SignOut? {
+            guard isAuthenticated else {
+                return LogtoClientErrors.SignOut(type: .notAuthenticated, innerError: nil)
+            }
+
+            if let postLogoutRedirectUri, !Self.isValidRedirectUri(postLogoutRedirectUri) {
+                _ = await clearCredentials()
+                return LogtoClientErrors.SignOut(type: .invalidRedirectUri, innerError: nil)
+            }
+
+            let tokenToRevoke = clearLocalCredentials()
+            var resultError: LogtoClientErrors.SignOut?
+
+            let oidcConfig: LogtoCore.OidcConfigResponse
+
             do {
-                let oidcConfig = try await fetchOidcConfig()
-                try await LogtoCore.revoke(
-                    useSession: networkSession,
-                    token: token,
-                    revocationEndpoint: oidcConfig.revocationEndpoint,
-                    clientId: logtoConfig.appId
-                )
-                return nil
+                oidcConfig = try await fetchOidcConfig()
             } catch {
-                return LogtoClientErrors.SignOut(type: .unableToRevokeToken, innerError: error)
+                return LogtoClientErrors.SignOut(type: .unableToFetchOidcConfig, innerError: error)
+            }
+
+            if let refreshToken = tokenToRevoke {
+                do {
+                    try await revokeRefreshToken(refreshToken, revocationEndpoint: oidcConfig.revocationEndpoint)
+                } catch {
+                    resultError = LogtoClientErrors.SignOut(type: .unableToRevokeToken, innerError: error)
+                }
+            }
+
+            do {
+                let signOutUri = try LogtoCore.generateSignOutUri(
+                    endSessionEndpoint: oidcConfig.endSessionEndpoint,
+                    clientId: logtoConfig.appId,
+                    postLogoutRedirectUri: postLogoutRedirectUri
+                )
+
+                try await startSignOutSession(
+                    with: signOutUri,
+                    postLogoutRedirectUri: postLogoutRedirectUri.flatMap(URL.init(string:)),
+                    authenticationSessionFactory: authenticationSessionFactory
+                )
+            } catch let error as LogtoErrors.UrlConstruction {
+                return LogtoClientErrors.SignOut(type: .unableToConstructSignOutUri, innerError: error)
+            } catch {
+                return LogtoClientErrors.SignOut(type: .unableToLaunchBrowser, innerError: error)
+            }
+
+            return resultError
+        }
+
+        @MainActor
+        private func startSignOutSession(
+            with signOutUri: URL,
+            postLogoutRedirectUri: URL?,
+            authenticationSessionFactory: @escaping LogtoASWebAuthenticationSession.AuthenticationSessionFactory
+        ) async throws {
+            try await withCheckedThrowingContinuation { continuation in
+                let resolver = LogtoSignOutSessionContinuation(continuation)
+                let session = authenticationSessionFactory(
+                    signOutUri,
+                    postLogoutRedirectUri.flatMap(LogtoASWebAuthenticationSession.callbackURLScheme(for:))
+                ) { [weak self] callbackUri, error in
+                    self?.signOutAuthenticationSession = nil
+                    self?.signOutPresentationContextProvider = nil
+
+                    if let error {
+                        if Self.isUserCancel(error) {
+                            resolver.resume()
+                            return
+                        }
+
+                        resolver.resume(throwing: error)
+                        return
+                    }
+
+                    guard let callbackUri else {
+                        resolver.resume()
+                        return
+                    }
+
+                    guard let postLogoutRedirectUri else {
+                        resolver.resume()
+                        return
+                    }
+
+                    guard Self.isCallbackUri(callbackUri, matching: postLogoutRedirectUri) else {
+                        resolver.resume(throwing: LogtoSignOutSessionError())
+                        return
+                    }
+
+                    resolver.resume()
+                }
+
+                let presentationContextProvider = LogtoAuthContext()
+                signOutPresentationContextProvider = presentationContextProvider
+                session.presentationContextProvider = presentationContextProvider
+                session.prefersEphemeralWebBrowserSession = logtoConfig.prefersEphemeralWebBrowserSession
+                signOutAuthenticationSession = session
+
+                let didStart = session.start()
+
+                guard didStart else {
+                    signOutAuthenticationSession = nil
+                    signOutPresentationContextProvider = nil
+                    resolver.resume(throwing: LogtoSignOutSessionError())
+                    return
+                }
             }
         }
 
-        return nil
+        private static func isValidRedirectUri(_ uri: String) -> Bool {
+            guard
+                let components = URLComponents(string: uri),
+                let scheme = components.scheme,
+                components.fragment == nil
+            else {
+                return false
+            }
+
+            guard let schemeRange = uri.range(of: "\(scheme):", options: [.anchored, .caseInsensitive]) else {
+                return false
+            }
+
+            return uri[schemeRange.upperBound...].hasPrefix("/")
+        }
+
+        private static func isCallbackUri(_ callbackUri: URL, matching postLogoutRedirectUri: URL) -> Bool {
+            callbackUri.scheme?.lowercased() == postLogoutRedirectUri.scheme?.lowercased()
+                && callbackUri.host?.lowercased() == postLogoutRedirectUri.host?.lowercased()
+                && callbackUri.path == postLogoutRedirectUri.path
+        }
+
+        private static func isUserCancel(_ error: Error) -> Bool {
+            let error = error as NSError
+            return error.domain == ASWebAuthenticationSessionError.errorDomain
+                && error.code == ASWebAuthenticationSessionError.Code.canceledLogin.rawValue
+        }
     }
-}
+#endif

--- a/Sources/LogtoClient/LogtoClient/LogtoClient.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient.swift
@@ -5,6 +5,9 @@
 //  Created by Gao Sun on 2022/1/21.
 //
 
+#if os(iOS)
+    import AuthenticationServices
+#endif
 import Foundation
 import KeychainAccess
 import Logto
@@ -20,6 +23,10 @@ public class LogtoClient {
 
     var accessTokenMap = [String: AccessToken]()
     var isSigningIn = false
+    #if os(iOS)
+        var signOutAuthenticationSession: LogtoSystemAuthenticationSession?
+        var signOutPresentationContextProvider: ASWebAuthenticationPresentationContextProviding?
+    #endif
 
     // MARK: Public Variables
 

--- a/Sources/LogtoClient/Types/LogtoClientErrorTypes.swift
+++ b/Sources/LogtoClient/Types/LogtoClientErrorTypes.swift
@@ -58,6 +58,8 @@ public enum LogtoClientErrorTypes {
         case unableToFetchOidcConfig
         /// Unable to construct Sign-out URI for the given post logout redirect URI or OIDC config.
         case unableToConstructSignOutUri
+        /// The sign-out callback URI is not valid.
+        case unexpectedSignOutCallback
         /// Unable to launch the browser sign-out session.
         case unableToLaunchBrowser
         /// Unable to revoke token in the OIDC provider.

--- a/Sources/LogtoClient/Types/LogtoClientErrorTypes.swift
+++ b/Sources/LogtoClient/Types/LogtoClientErrorTypes.swift
@@ -50,6 +50,16 @@ public enum LogtoClientErrorTypes {
     }
 
     public enum SignOut: String {
+        /// The user is not authenticated.
+        case notAuthenticated
+        /// The post logout redirect URI is invalid.
+        case invalidRedirectUri
+        /// Unable to fetch OIDC config from the OIDC provider.
+        case unableToFetchOidcConfig
+        /// Unable to construct Sign-out URI for the given post logout redirect URI or OIDC config.
+        case unableToConstructSignOutUri
+        /// Unable to launch the browser sign-out session.
+        case unableToLaunchBrowser
         /// Unable to revoke token in the OIDC provider.
         /// Usually this error is safe to ignore.
         case unableToRevokeToken

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignOut.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignOut.swift
@@ -181,6 +181,24 @@ extension LogtoClientTests {
         }
 
         @MainActor
+        func testSignOutUnexpectedCallbackUri() async {
+            let client = buildClient(withToken: true)
+
+            let error = await client
+                .signOut(postLogoutRedirectUri: "io.logto.test://signed-out") { _, _, completionHandler in
+                    SignOutSystemAuthenticationSessionMock(
+                        callbackUri: URL(string: "io.logto.test://unexpected"),
+                        completionHandler: completionHandler
+                    )
+                }
+
+            XCTAssertEqual(error?.type, .unexpectedSignOutCallback)
+            XCTAssertNil(client.refreshToken)
+            XCTAssertNil(client.idToken)
+            XCTAssertEqual(client.accessTokenMap.count, 0)
+        }
+
+        @MainActor
         func testSignOutWithoutRedirectCanceledByUserCompletesSuccessfully() async {
             let client = buildClient(withToken: true)
             let cancelError = NSError(

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignOut.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignOut.swift
@@ -1,10 +1,14 @@
+import Logto
 @testable import LogtoClient
 import XCTest
+#if os(iOS)
+    import AuthenticationServices
+#endif
 
 extension LogtoClientTests {
-    func testSignOutOk() async {
+    func testClearCredentialsOk() async {
         let client = buildClient(withToken: true)
-        let error = await client.signOut()
+        let error = await client.clearCredentials()
 
         XCTAssertNil(error)
         XCTAssertNil(client.refreshToken)
@@ -12,20 +16,272 @@ extension LogtoClientTests {
         XCTAssertEqual(client.accessTokenMap.count, 0)
     }
 
-    func testSignOutUnableToFetchOidcConfig() async {
-        let client = buildClient(withOidcEndpoint: "/bad", withToken: true)
-        let error = await client.signOut()
+    func testClearCredentialsNotAuthenticated() async {
+        let client = buildClient()
+        let error = await client.clearCredentials()
 
-        XCTAssertEqual(error?.type, .unableToRevokeToken)
+        XCTAssertEqual(error?.type, .notAuthenticated)
     }
 
-    func testSignOutUnableToRevokeToken() async {
+    func testClearCredentialsUnableToFetchOidcConfig() async {
+        let client = buildClient(withOidcEndpoint: "/bad", withToken: true)
+        let error = await client.clearCredentials()
+
+        XCTAssertEqual(error?.type, .unableToFetchOidcConfig)
+    }
+
+    func testClearCredentialsUnableToRevokeToken() async {
         let client = buildClient(withOidcEndpoint: "/oidc_config:bad", withToken: true)
-        let error = await client.signOut()
+        let error = await client.clearCredentials()
 
         XCTAssertEqual(error?.type, .unableToRevokeToken)
         XCTAssertNil(client.refreshToken)
         XCTAssertNil(client.idToken)
         XCTAssertEqual(client.accessTokenMap.count, 0)
     }
+
+    #if os(iOS)
+        @MainActor
+        func testSignOutOk() async throws {
+            let client = buildClient(withToken: true)
+            let postLogoutRedirectUri = try XCTUnwrap(URL(string: "io.logto.test://signed-out"))
+            var capturedSignOutUri: URL?
+            var capturedCallbackURLScheme: String?
+            var mockSession: SignOutSystemAuthenticationSessionMock!
+
+            let error = await client.signOut(
+                postLogoutRedirectUri: postLogoutRedirectUri.absoluteString
+            ) { signOutUri, callbackURLScheme, completionHandler in
+                capturedSignOutUri = signOutUri
+                capturedCallbackURLScheme = callbackURLScheme
+
+                mockSession = SignOutSystemAuthenticationSessionMock(
+                    callbackUri: postLogoutRedirectUri,
+                    completionHandler: completionHandler
+                )
+                return mockSession
+            }
+
+            XCTAssertNil(error)
+            XCTAssertNil(client.refreshToken)
+            XCTAssertNil(client.idToken)
+            XCTAssertEqual(client.accessTokenMap.count, 0)
+            XCTAssertEqual(capturedSignOutUri?.scheme, "https")
+            XCTAssertEqual(capturedSignOutUri?.host, "logto.dev")
+            XCTAssertEqual(capturedSignOutUri?.path, "/end:good")
+            XCTAssertEqual(capturedCallbackURLScheme, "io.logto.test")
+            XCTAssertTrue(try queryItems(in: XCTUnwrap(capturedSignOutUri)).contains(URLQueryItem(
+                name: "client_id",
+                value: "foo"
+            )))
+            XCTAssertTrue(try queryItems(in: XCTUnwrap(capturedSignOutUri)).contains(URLQueryItem(
+                name: "post_logout_redirect_uri",
+                value: postLogoutRedirectUri.absoluteString
+            )))
+            XCTAssertFalse(try queryItems(in: XCTUnwrap(capturedSignOutUri)).contains(URLQueryItem(
+                name: "id_token_hint",
+                value: initialIdToken
+            )))
+            XCTAssertFalse(mockSession.prefersEphemeralWebBrowserSession)
+            XCTAssertNotNil(mockSession.presentationContextProvider)
+        }
+
+        @MainActor
+        func testSignOutWithoutRedirectOk() async throws {
+            let client = buildClient(withToken: true)
+            var capturedSignOutUri: URL?
+            var capturedCallbackURLScheme: String?
+            var mockSession: SignOutSystemAuthenticationSessionMock!
+
+            let error = await client.signOut { signOutUri, callbackURLScheme, completionHandler in
+                capturedSignOutUri = signOutUri
+                capturedCallbackURLScheme = callbackURLScheme
+                mockSession = SignOutSystemAuthenticationSessionMock(completionHandler: completionHandler)
+                return mockSession
+            }
+
+            XCTAssertNil(error)
+            XCTAssertNil(client.refreshToken)
+            XCTAssertNil(client.idToken)
+            XCTAssertEqual(client.accessTokenMap.count, 0)
+            XCTAssertNil(capturedCallbackURLScheme)
+            XCTAssertNotNil(mockSession.presentationContextProvider)
+
+            let items = try queryItems(in: XCTUnwrap(capturedSignOutUri))
+            XCTAssertTrue(items.contains(URLQueryItem(name: "client_id", value: "foo")))
+            XCTAssertFalse(items.contains { $0.name == "post_logout_redirect_uri" })
+        }
+
+        @MainActor
+        func testSignOutNotAuthenticated() async {
+            let client = buildClient()
+            var didCreateSession = false
+
+            let error = await client.signOut { _, _, completionHandler in
+                didCreateSession = true
+                return SignOutSystemAuthenticationSessionMock(completionHandler: completionHandler)
+            }
+
+            XCTAssertEqual(error?.type, .notAuthenticated)
+            XCTAssertFalse(didCreateSession)
+        }
+
+        @MainActor
+        func testSignOutInvalidRedirectUri() async {
+            let client = buildClient(withToken: true)
+            var didCreateSession = false
+
+            let error = await client.signOut(postLogoutRedirectUri: "io.logto.test://signed-out#invalid") {
+                _, _, completionHandler in
+                didCreateSession = true
+                return SignOutSystemAuthenticationSessionMock(completionHandler: completionHandler)
+            }
+
+            XCTAssertEqual(error?.type, .invalidRedirectUri)
+            XCTAssertFalse(didCreateSession)
+            XCTAssertNil(client.refreshToken)
+            XCTAssertNil(client.idToken)
+            XCTAssertEqual(client.accessTokenMap.count, 0)
+        }
+
+        @MainActor
+        func testSignOutUnableToFetchOidcConfig() async {
+            let client = buildClient(withOidcEndpoint: "/bad", withToken: true)
+            var didCreateSession = false
+
+            let error = await client
+                .signOut(postLogoutRedirectUri: "io.logto.test://signed-out") { _, _, completionHandler in
+                    didCreateSession = true
+                    return SignOutSystemAuthenticationSessionMock(completionHandler: completionHandler)
+                }
+
+            XCTAssertEqual(error?.type, .unableToFetchOidcConfig)
+            XCTAssertFalse(didCreateSession)
+            XCTAssertNil(client.refreshToken)
+            XCTAssertNil(client.idToken)
+            XCTAssertEqual(client.accessTokenMap.count, 0)
+        }
+
+        @MainActor
+        func testSignOutReturnsRevokeErrorAfterBrowserSignOut() async {
+            let client = buildClient(withOidcEndpoint: "/oidc_config:bad", withToken: true)
+
+            let error = await client
+                .signOut(postLogoutRedirectUri: "io.logto.test://signed-out") { _, _, completionHandler in
+                    SignOutSystemAuthenticationSessionMock(
+                        callbackUri: URL(string: "io.logto.test://signed-out"),
+                        completionHandler: completionHandler
+                    )
+                }
+
+            XCTAssertEqual(error?.type, .unableToRevokeToken)
+            XCTAssertNil(client.refreshToken)
+            XCTAssertNil(client.idToken)
+            XCTAssertEqual(client.accessTokenMap.count, 0)
+        }
+
+        @MainActor
+        func testSignOutWithoutRedirectCanceledByUserCompletesSuccessfully() async {
+            let client = buildClient(withToken: true)
+            let cancelError = NSError(
+                domain: ASWebAuthenticationSessionError.errorDomain,
+                code: ASWebAuthenticationSessionError.Code.canceledLogin.rawValue
+            )
+
+            let error = await client.signOut { _, callbackURLScheme, completionHandler in
+                XCTAssertNil(callbackURLScheme)
+                return SignOutSystemAuthenticationSessionMock(
+                    callbackError: cancelError,
+                    completionHandler: completionHandler
+                )
+            }
+
+            XCTAssertNil(error)
+            XCTAssertNil(client.refreshToken)
+            XCTAssertNil(client.idToken)
+            XCTAssertEqual(client.accessTokenMap.count, 0)
+        }
+
+        @MainActor
+        func testSignOutCanceledByUserCompletesSuccessfully() async {
+            let client = buildClient(withToken: true)
+            let cancelError = NSError(
+                domain: ASWebAuthenticationSessionError.errorDomain,
+                code: ASWebAuthenticationSessionError.Code.canceledLogin.rawValue
+            )
+
+            let error = await client
+                .signOut(postLogoutRedirectUri: "io.logto.test://signed-out") { _, _, completionHandler in
+                    SignOutSystemAuthenticationSessionMock(
+                        callbackError: cancelError,
+                        completionHandler: completionHandler
+                    )
+                }
+
+            XCTAssertNil(error)
+            XCTAssertNil(client.refreshToken)
+            XCTAssertNil(client.idToken)
+            XCTAssertEqual(client.accessTokenMap.count, 0)
+        }
+
+        @MainActor
+        func testSignOutUnableToLaunchBrowserWhenSessionDoesNotStart() async {
+            let client = buildClient(withToken: true)
+
+            let error = await client
+                .signOut(postLogoutRedirectUri: "io.logto.test://signed-out") { _, _, completionHandler in
+                    SignOutSystemAuthenticationSessionMock(
+                        shouldStart: false,
+                        completesOnStart: false,
+                        completionHandler: completionHandler
+                    )
+                }
+
+            XCTAssertEqual(error?.type, .unableToLaunchBrowser)
+            XCTAssertNil(client.refreshToken)
+            XCTAssertNil(client.idToken)
+            XCTAssertEqual(client.accessTokenMap.count, 0)
+        }
+
+        private func queryItems(in url: URL) -> [URLQueryItem] {
+            URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems ?? []
+        }
+    #endif
 }
+
+#if os(iOS)
+    private final class SignOutSystemAuthenticationSessionMock: LogtoSystemAuthenticationSession {
+        var presentationContextProvider: ASWebAuthenticationPresentationContextProviding?
+        var prefersEphemeralWebBrowserSession = false
+
+        private let shouldStart: Bool
+        private let callbackUri: URL?
+        private let callbackError: Error?
+        private let completesOnStart: Bool
+        private let completionHandler: LogtoASWebAuthenticationSession.CompletionHandler
+
+        init(
+            shouldStart: Bool = true,
+            callbackUri: URL? = nil,
+            callbackError: Error? = nil,
+            completesOnStart: Bool = true,
+            completionHandler: @escaping LogtoASWebAuthenticationSession.CompletionHandler
+        ) {
+            self.shouldStart = shouldStart
+            self.callbackUri = callbackUri
+            self.callbackError = callbackError
+            self.completesOnStart = completesOnStart
+            self.completionHandler = completionHandler
+        }
+
+        func start() -> Bool {
+            if completesOnStart {
+                completionHandler(callbackUri, callbackError)
+            }
+
+            return shouldStart
+        }
+
+        func cancel() {}
+    }
+#endif

--- a/Tests/LogtoTests/LogtoCoreTests+Generate.swift
+++ b/Tests/LogtoTests/LogtoCoreTests+Generate.swift
@@ -196,7 +196,7 @@ extension LogtoCoreTests {
 
     func testGenerateSignOutUri() throws {
         XCTAssertThrowsError(try LogtoCore
-            .generateSignOutUri(endSessionEndpoint: "???", idToken: "", postLogoutRedirectUri: nil))
+            .generateSignOutUri(endSessionEndpoint: "???", clientId: "", postLogoutRedirectUri: nil))
         {
             XCTAssertEqual(
                 $0 as? LogtoErrors.UrlConstruction,
@@ -205,11 +205,11 @@ extension LogtoCoreTests {
         }
 
         let endSessionEndpoint = "https://logto.dev/oidc/session/end"
-        let idToken = "foo"
+        let clientId = "foo"
         let postLogoutRedirectUri = "https://localhost"
         let url = try LogtoCore.generateSignOutUri(
             endSessionEndpoint: endSessionEndpoint,
-            idToken: idToken,
+            clientId: clientId,
             postLogoutRedirectUri: postLogoutRedirectUri
         )
 
@@ -217,8 +217,18 @@ extension LogtoCoreTests {
         XCTAssertEqual(url.host, "logto.dev")
         XCTAssertEqual(url.path, "/oidc/session/end")
         XCTAssertTrue(validate(url: url, queryItems: [
-            URLQueryItem(name: "id_token_hint", value: idToken),
+            URLQueryItem(name: "client_id", value: clientId),
             URLQueryItem(name: "post_logout_redirect_uri", value: postLogoutRedirectUri),
+        ]))
+
+        let urlWithoutRedirect = try LogtoCore.generateSignOutUri(
+            endSessionEndpoint: endSessionEndpoint,
+            clientId: clientId,
+            postLogoutRedirectUri: nil
+        )
+
+        XCTAssertTrue(validate(url: urlWithoutRedirect, queryItems: [
+            URLQueryItem(name: "client_id", value: clientId),
         ]))
     }
 }


### PR DESCRIPTION
## Summary
- Add iOS browser sign-out through `ASWebAuthenticationSession`, with and without post-logout redirect.
- Add `clearCredentials()` for local-only sign-out and expand sign-out error coverage.
- Align sign-out URI generation with Kotlin by using `client_id` and optional `post_logout_redirect_uri`.
- Update the SwiftUI demo to show `Sign Out`, `Sign Out Without Redirect`, and `Clear Credentials` without committing real demo credentials.

## Test
- `swift run --package-path BuildTools swiftformat --lint .`
- `swift test`
- `xcodebuild test -scheme LogtoSDK-Package -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.3.1'`
