### PR TITLE
feat: support HTTPS callbacks in iOS auth sessions

### DIFF
--- a/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
+++ b/Demos/SwiftUI Demo/SwiftUI Demo/ContentView.swift
@@ -14,7 +14,7 @@ import SwiftUI
 enum DemoAuthConfig {
     static let endpoint = "<YOUR_LOGTO_ENDPOINT>"
     static let appId = "<YOUR_APP_ID>"
-    static let redirectUri = "logto-demo://callback"
+    static let redirectUri = "logto-demo://callback" // e.g. "io.logto://callback" or "https://example.com/callback"
     static let postLogoutRedirectUri = "logto-demo://signed-out"
 
     // MARK: Optional config items

--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ CocoaPods [does not support local dependency](https://github.com/CocoaPods/Cocoa
 
 In most cases, you only need to import `LogtoClient`, which includes `Logto` under the hood.
 
+## Redirect URIs on iOS
+
+`signInWithBrowser(redirectUri:)` supports both custom scheme redirect URIs and HTTPS Universal Links.
+
+For a custom scheme such as `io.logto.app://callback`, register the scheme in your app's `Info.plist` and add the same URI to your Logto application's Redirect URIs. This works with automatic `ASWebAuthenticationSession` completion on all supported iOS versions.
+
+### Use Universal Links instead of a custom scheme
+
+You can also use an HTTPS redirect URI such as `https://example.com/callback`:
+
+1. Add the Associated Domains capability to your app.
+2. Configure the domain as `webcredentials:example.com` so `ASWebAuthenticationSession` can match HTTPS callbacks on iOS 17.4 and newer.
+3. If the same URL should also open your app as a Universal Link outside the authentication session, configure `applinks:example.com` and host a valid `apple-app-site-association` file for the domain and path.
+4. Add the HTTPS URI to your Logto application's Redirect URIs.
+
+On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callback matching API so HTTPS redirects can automatically complete and dismiss the session. On older iOS versions, the authorization request can still use the HTTPS redirect URI, but the session may not close automatically unless your app handles the Universal Link callback itself. Keep a custom scheme redirect as a compatibility option if you need automatic completion on older iOS versions.
+
 ## Resources
 
 [![Website](https://img.shields.io/badge/website-logto.io-8262F8.svg)](https://logto.io/)

--- a/Sources/LogtoClient/LogtoAuthSession/LogtoASWebAuthenticationSession.swift
+++ b/Sources/LogtoClient/LogtoAuthSession/LogtoASWebAuthenticationSession.swift
@@ -49,9 +49,38 @@
 
     class LogtoASWebAuthenticationSession: LogtoAuthSession {
         typealias CompletionHandler = (URL?, Error?) -> Void
+
+        enum AuthenticationCallback: Equatable {
+            case customScheme(String)
+            case https(host: String, path: String)
+            case unsupported
+
+            var callbackURLScheme: String? {
+                guard case let .customScheme(scheme) = self else {
+                    return nil
+                }
+
+                return scheme
+            }
+
+            #if compiler(>=5.10)
+                @available(iOS 17.4, *)
+                var callback: ASWebAuthenticationSession.Callback? {
+                    switch self {
+                    case let .customScheme(scheme):
+                        return .customScheme(scheme)
+                    case let .https(host, path):
+                        return .https(host: host, path: path)
+                    case .unsupported:
+                        return nil
+                    }
+                }
+            #endif
+        }
+
         typealias AuthenticationSessionFactory = (
             _ url: URL,
-            _ callbackURLScheme: String?,
+            _ callback: AuthenticationCallback,
             _ completionHandler: @escaping CompletionHandler
         ) -> LogtoSystemAuthenticationSession
 
@@ -123,33 +152,59 @@
 
         static func createAuthenticationSession(
             url: URL,
-            callbackURLScheme: String?,
+            callback: AuthenticationCallback,
             completionHandler: @escaping CompletionHandler
         ) -> LogtoSystemAuthenticationSession {
-            ASWebAuthenticationSession(
+            #if compiler(>=5.10)
+                if #available(iOS 17.4, *), let callback = callback.callback {
+                    return ASWebAuthenticationSession(
+                        url: url,
+                        callback: callback,
+                        completionHandler: completionHandler
+                    )
+                }
+            #endif
+
+            return ASWebAuthenticationSession(
                 url: url,
-                callbackURLScheme: callbackURLScheme,
+                callbackURLScheme: callback.callbackURLScheme,
                 completionHandler: completionHandler
             )
         }
 
-        static func callbackURLScheme(for url: URL) -> String? {
-            guard let scheme = url.scheme?.lowercased(), !["http", "https"].contains(scheme) else {
-                return nil
+        static func authenticationCallback(for redirectUri: URL) -> AuthenticationCallback {
+            guard let scheme = redirectUri.scheme?.lowercased() else {
+                return .unsupported
             }
 
-            return scheme
+            switch scheme {
+            case "https":
+                guard let host = redirectUri.host?.lowercased() else {
+                    return .unsupported
+                }
+
+                let path = redirectUri.path.isEmpty ? "/" : redirectUri.path
+                return .https(host: host, path: path)
+            case "http":
+                return .unsupported
+            default:
+                return .customScheme(scheme)
+            }
         }
 
-        private var callbackURLScheme: String? {
-            Self.callbackURLScheme(for: redirectUri)
+        static func callbackURLScheme(for url: URL) -> String? {
+            authenticationCallback(for: url).callbackURLScheme
+        }
+
+        private var authenticationCallback: AuthenticationCallback {
+            Self.authenticationCallback(for: redirectUri)
         }
 
         private func startAuthenticationSession(with authUri: URL) async throws -> LogtoCore.CodeTokenResponse {
             try await withCheckedThrowingContinuation { continuation in
                 let resolver = LogtoASWebAuthenticationSessionContinuation(continuation)
                 let session = authenticationSessionFactory(authUri,
-                                                           callbackURLScheme)
+                                                           authenticationCallback)
                 { [weak self] callbackUri, error in
                     guard let self else {
                         resolver.resume(throwing: Errors.SignIn(type: .authFailed, innerError: nil))

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignIn.swift
@@ -68,6 +68,11 @@ public extension LogtoClient {
         /**
          Start a sign in session with ASWebAuthenticationSession. If the function returns with no error threw, it means the user has signed in successfully.
 
+         The redirect URI can use a custom scheme or an HTTPS Universal Link:
+         - Custom scheme redirect URIs, for example `io.logto.app://callback`, can be matched and dismissed automatically on all supported iOS versions.
+         - HTTPS Universal Link redirect URIs, for example `https://example.com/callback`, require Associated Domains configuration with the `webcredentials` service and iOS 17.4 or newer for ASWebAuthenticationSession to match the callback and dismiss automatically.
+         - On older iOS versions, an HTTPS redirect can still be used in the authorization request, but ASWebAuthenticationSession may not close automatically unless the app handles the Universal Link callback itself.
+
          - Parameters:
             - redirectUri: One of Redirect URIs of this application.
             - loginHint: Login hint indicates the current user (usually an email address or phone number).

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
@@ -49,6 +49,8 @@ public extension LogtoClient {
         /**
          Sign out from Logto in the browser and clear all local credentials.
 
+         The post sign-out redirect URI can use a custom scheme or an HTTPS Universal Link. Custom scheme redirects can be matched and dismissed automatically on all supported iOS versions. HTTPS redirects require Associated Domains configuration with the `webcredentials` service and iOS 17.4 or newer for ASWebAuthenticationSession to match the callback and dismiss automatically.
+
          - Parameter postLogoutRedirectUri: One of Post sign-out redirect URIs of this application. When omitted, the browser stays on the Logto sign-out page and the user can dismiss it manually.
          - Returns: An error if the browser sign-out or token revocation failed.
          */
@@ -201,7 +203,8 @@ extension LogtoClient {
                 let resolver = LogtoSignOutSessionContinuation(continuation)
                 let session = authenticationSessionFactory(
                     signOutUri,
-                    postLogoutRedirectUri.flatMap(LogtoASWebAuthenticationSession.callbackURLScheme(for:))
+                    postLogoutRedirectUri
+                        .map(LogtoASWebAuthenticationSession.authenticationCallback(for:)) ?? .unsupported
                 ) { [weak self] callbackUri, error in
                     self?.signOutAuthenticationSession = nil
                     self?.signOutPresentationContextProvider = nil

--- a/Tests/LogtoClientTests/LogtoAuthSession/LogtoASWebAuthenticationSessionTests.swift
+++ b/Tests/LogtoClientTests/LogtoAuthSession/LogtoASWebAuthenticationSessionTests.swift
@@ -80,12 +80,52 @@
             return components.url!
         }
 
+        func testAuthenticationCallbackForCustomSchemeRedirect() throws {
+            let redirectUri = try XCTUnwrap(URL(string: "io.logto.test://callback"))
+            let callback = LogtoASWebAuthenticationSession.authenticationCallback(for: redirectUri)
+
+            XCTAssertEqual(callback, .customScheme("io.logto.test"))
+            XCTAssertEqual(callback.callbackURLScheme, "io.logto.test")
+        }
+
+        func testAuthenticationCallbackForHttpsRedirect() throws {
+            let redirectUri = try XCTUnwrap(URL(string: "https://Example.com/callback"))
+            let callback = LogtoASWebAuthenticationSession.authenticationCallback(for: redirectUri)
+
+            XCTAssertEqual(callback, .https(host: "example.com", path: "/callback"))
+            XCTAssertNil(callback.callbackURLScheme)
+        }
+
+        func testAuthenticationCallbackForHttpsRedirectWithoutPath() throws {
+            let redirectUri = try XCTUnwrap(URL(string: "https://Example.com"))
+            let callback = LogtoASWebAuthenticationSession.authenticationCallback(for: redirectUri)
+
+            XCTAssertEqual(callback, .https(host: "example.com", path: "/"))
+            XCTAssertNil(callback.callbackURLScheme)
+        }
+
+        func testAuthenticationCallbackForHttpRedirect() throws {
+            let redirectUri = try XCTUnwrap(URL(string: "http://example.com/callback"))
+            let callback = LogtoASWebAuthenticationSession.authenticationCallback(for: redirectUri)
+
+            XCTAssertEqual(callback, .unsupported)
+            XCTAssertNil(callback.callbackURLScheme)
+        }
+
+        func testAuthenticationCallbackForHttpsRedirectWithoutHost() throws {
+            let redirectUri = try XCTUnwrap(URL(string: "https:///callback"))
+            let callback = LogtoASWebAuthenticationSession.authenticationCallback(for: redirectUri)
+
+            XCTAssertEqual(callback, .unsupported)
+            XCTAssertNil(callback.callbackURLScheme)
+        }
+
         @MainActor
         func testStartOk() async throws {
             NetworkSessionMock.shared.tokenRequestCount = 0
 
             let contextProvider = PresentationContextProviderMock()
-            var capturedCallbackURLScheme: String?
+            var capturedCallback: LogtoASWebAuthenticationSession.AuthenticationCallback?
             var mockSession: LogtoSystemAuthenticationSessionMock!
             var authSession: LogtoASWebAuthenticationSession!
 
@@ -99,8 +139,8 @@
                 oidcConfig: getMockOidcConfig(),
                 redirectUri: customRedirectUri,
                 presentationContextProvider: contextProvider
-            ) { authUri, callbackURLScheme, completionHandler in
-                capturedCallbackURLScheme = callbackURLScheme
+            ) { authUri, callback, completionHandler in
+                capturedCallback = callback
                 XCTAssertEqual(authUri.scheme, "https")
                 XCTAssertEqual(authUri.host, "logto.dev")
 
@@ -114,7 +154,7 @@
             let response = try await authSession.start()
 
             XCTAssertEqual(response.accessToken, "123")
-            XCTAssertEqual(capturedCallbackURLScheme, "io.logto.test")
+            XCTAssertEqual(capturedCallback, .customScheme("io.logto.test"))
             XCTAssertTrue(mockSession.prefersEphemeralWebBrowserSession)
             XCTAssertNotNil(mockSession.presentationContextProvider)
         }
@@ -191,33 +231,32 @@
             XCTFail()
         }
 
-        func testUniversalLinkRedirectDoesNotUseCallbackURLScheme() async throws {
-            let redirectUri = try XCTUnwrap(URL(string: "https://example.com/callback"))
-            var capturedCallbackURLScheme: String?
+        @MainActor
+        func testHttpsRedirectUsesHttpsCallback() async throws {
+            NetworkSessionMock.shared.tokenRequestCount = 0
 
-            let authSession = try LogtoASWebAuthenticationSession(
+            let redirectUri = try XCTUnwrap(URL(string: "https://example.com/callback"))
+            var capturedCallback: LogtoASWebAuthenticationSession.AuthenticationCallback?
+            var authSession: LogtoASWebAuthenticationSession!
+
+            authSession = try LogtoASWebAuthenticationSession(
                 useSession: NetworkSessionMock.shared,
                 logtoConfig: LogtoConfig(endpoint: "https://logto.dev", appId: "foo"),
                 oidcConfig: getMockOidcConfig(),
                 redirectUri: redirectUri
-            ) { _, callbackURLScheme, completionHandler in
-                capturedCallbackURLScheme = callbackURLScheme
+            ) { _, callback, completionHandler in
+                capturedCallback = callback
                 return LogtoSystemAuthenticationSessionMock(
-                    shouldStart: false,
-                    completesOnStart: false,
+                    callbackUri: self.getCallbackUri(redirectUri: redirectUri, state: authSession.state),
                     completionHandler: completionHandler
                 )
             }
 
-            do {
-                _ = try await authSession.start()
-            } catch let error as LogtoClientErrors.SignIn {
-                XCTAssertEqual(error.type, .authFailed)
-                XCTAssertNil(capturedCallbackURLScheme)
-                return
-            }
+            let response = try await authSession.start()
 
-            XCTFail()
+            XCTAssertEqual(response.accessToken, "123")
+            XCTAssertEqual(capturedCallback, .https(host: "example.com", path: "/callback"))
+            XCTAssertNil(capturedCallback?.callbackURLScheme)
         }
     }
 #endif

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignOut.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignOut.swift
@@ -46,14 +46,14 @@ extension LogtoClientTests {
             let client = buildClient(withToken: true)
             let postLogoutRedirectUri = try XCTUnwrap(URL(string: "io.logto.test://signed-out"))
             var capturedSignOutUri: URL?
-            var capturedCallbackURLScheme: String?
+            var capturedCallback: LogtoASWebAuthenticationSession.AuthenticationCallback?
             var mockSession: SignOutSystemAuthenticationSessionMock!
 
             let error = await client.signOut(
                 postLogoutRedirectUri: postLogoutRedirectUri.absoluteString
-            ) { signOutUri, callbackURLScheme, completionHandler in
+            ) { signOutUri, callback, completionHandler in
                 capturedSignOutUri = signOutUri
-                capturedCallbackURLScheme = callbackURLScheme
+                capturedCallback = callback
 
                 mockSession = SignOutSystemAuthenticationSessionMock(
                     callbackUri: postLogoutRedirectUri,
@@ -69,7 +69,7 @@ extension LogtoClientTests {
             XCTAssertEqual(capturedSignOutUri?.scheme, "https")
             XCTAssertEqual(capturedSignOutUri?.host, "logto.dev")
             XCTAssertEqual(capturedSignOutUri?.path, "/end:good")
-            XCTAssertEqual(capturedCallbackURLScheme, "io.logto.test")
+            XCTAssertEqual(capturedCallback, .customScheme("io.logto.test"))
             XCTAssertTrue(try queryItems(in: XCTUnwrap(capturedSignOutUri)).contains(URLQueryItem(
                 name: "client_id",
                 value: "foo"
@@ -87,15 +87,46 @@ extension LogtoClientTests {
         }
 
         @MainActor
+        func testSignOutWithHttpsRedirectUsesHttpsCallback() async throws {
+            let client = buildClient(withToken: true)
+            let postLogoutRedirectUri = try XCTUnwrap(URL(string: "https://example.com/signed-out"))
+            var capturedSignOutUri: URL?
+            var capturedCallback: LogtoASWebAuthenticationSession.AuthenticationCallback?
+
+            let error = await client.signOut(
+                postLogoutRedirectUri: postLogoutRedirectUri.absoluteString
+            ) { signOutUri, callback, completionHandler in
+                capturedSignOutUri = signOutUri
+                capturedCallback = callback
+
+                return SignOutSystemAuthenticationSessionMock(
+                    callbackUri: postLogoutRedirectUri,
+                    completionHandler: completionHandler
+                )
+            }
+
+            XCTAssertNil(error)
+            XCTAssertNil(client.refreshToken)
+            XCTAssertNil(client.idToken)
+            XCTAssertEqual(client.accessTokenMap.count, 0)
+            XCTAssertEqual(capturedCallback, .https(host: "example.com", path: "/signed-out"))
+            XCTAssertNil(capturedCallback?.callbackURLScheme)
+            XCTAssertTrue(try queryItems(in: XCTUnwrap(capturedSignOutUri)).contains(URLQueryItem(
+                name: "post_logout_redirect_uri",
+                value: postLogoutRedirectUri.absoluteString
+            )))
+        }
+
+        @MainActor
         func testSignOutWithoutRedirectOk() async throws {
             let client = buildClient(withToken: true)
             var capturedSignOutUri: URL?
-            var capturedCallbackURLScheme: String?
+            var capturedCallback: LogtoASWebAuthenticationSession.AuthenticationCallback?
             var mockSession: SignOutSystemAuthenticationSessionMock!
 
-            let error = await client.signOut { signOutUri, callbackURLScheme, completionHandler in
+            let error = await client.signOut { signOutUri, callback, completionHandler in
                 capturedSignOutUri = signOutUri
-                capturedCallbackURLScheme = callbackURLScheme
+                capturedCallback = callback
                 mockSession = SignOutSystemAuthenticationSessionMock(completionHandler: completionHandler)
                 return mockSession
             }
@@ -104,7 +135,7 @@ extension LogtoClientTests {
             XCTAssertNil(client.refreshToken)
             XCTAssertNil(client.idToken)
             XCTAssertEqual(client.accessTokenMap.count, 0)
-            XCTAssertNil(capturedCallbackURLScheme)
+            XCTAssertEqual(capturedCallback, .unsupported)
             XCTAssertNotNil(mockSession.presentationContextProvider)
 
             let items = try queryItems(in: XCTUnwrap(capturedSignOutUri))
@@ -206,8 +237,8 @@ extension LogtoClientTests {
                 code: ASWebAuthenticationSessionError.Code.canceledLogin.rawValue
             )
 
-            let error = await client.signOut { _, callbackURLScheme, completionHandler in
-                XCTAssertNil(callbackURLScheme)
+            let error = await client.signOut { _, callback, completionHandler in
+                XCTAssertEqual(callback, .unsupported)
                 return SignOutSystemAuthenticationSessionMock(
                     callbackError: cancelError,
                     completionHandler: completionHandler


### PR DESCRIPTION
## Summary
- Add an internal authentication callback abstraction for custom schemes, HTTPS callbacks, and unsupported redirects
- Use the iOS 17.4+ ASWebAuthenticationSession callback initializer when available, with legacy callbackURLScheme fallback for older systems
- Apply the same callback derivation to browser sign-out post-logout redirects from latest master
- Document custom scheme vs HTTPS callback behavior, including webcredentials/applinks setup notes

## Tests
- swift test
- xcodebuild test -scheme LogtoSDK-Package -destination 'id=076132F8-687F-4E71-AE91-BE09CCBFFFD4'
