### PR TITLE
fix: keep credentials and skip OIDC fetch on invalid sign-out redirect

### DIFF
--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
@@ -147,7 +147,7 @@ extension LogtoClient {
             }
 
             if let postLogoutRedirectUri, !Self.isValidRedirectUri(postLogoutRedirectUri) {
-                _ = await clearCredentials()
+                clearLocalCredentials()
                 return LogtoClientErrors.SignOut(type: .invalidRedirectUri, innerError: nil)
             }
 

--- a/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
+++ b/Sources/LogtoClient/LogtoClient/LogtoClient+SignOut.swift
@@ -147,7 +147,10 @@ extension LogtoClient {
             }
 
             if let postLogoutRedirectUri, !Self.isValidRedirectUri(postLogoutRedirectUri) {
-                clearLocalCredentials()
+                // Treat an invalid redirect URI as a pure input-validation failure and keep all
+                // credentials intact. Clearing them here would leave the Logto session alive on the
+                // provider while marking the client signed out, and the caller would no longer be
+                // able to perform a complete sign-out after fixing the URI.
                 return LogtoClientErrors.SignOut(type: .invalidRedirectUri, innerError: nil)
             }
 

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignOut.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignOut.swift
@@ -159,7 +159,8 @@ extension LogtoClientTests {
 
         @MainActor
         func testSignOutInvalidRedirectUri() async {
-            let client = buildClient(withToken: true)
+            let networkSession = SignOutNetworkSessionSpy()
+            let client = buildClient(withToken: true, session: networkSession)
             var didCreateSession = false
 
             let error = await client.signOut(postLogoutRedirectUri: "io.logto.test://signed-out#invalid") {
@@ -170,6 +171,7 @@ extension LogtoClientTests {
 
             XCTAssertEqual(error?.type, .invalidRedirectUri)
             XCTAssertFalse(didCreateSession)
+            XCTAssertEqual(networkSession.requestCount, 0)
             XCTAssertNil(client.refreshToken)
             XCTAssertNil(client.idToken)
             XCTAssertEqual(client.accessTokenMap.count, 0)
@@ -332,5 +334,16 @@ extension LogtoClientTests {
         }
 
         func cancel() {}
+    }
+
+    private struct SignOutNetworkSessionSpyError: Error {}
+
+    private final class SignOutNetworkSessionSpy: NetworkSession {
+        private(set) var requestCount = 0
+
+        func loadData(with _: URLRequest) async -> (Data?, Error?) {
+            requestCount += 1
+            return (nil, SignOutNetworkSessionSpyError())
+        }
     }
 #endif

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignOut.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests+SignOut.swift
@@ -172,9 +172,10 @@ extension LogtoClientTests {
             XCTAssertEqual(error?.type, .invalidRedirectUri)
             XCTAssertFalse(didCreateSession)
             XCTAssertEqual(networkSession.requestCount, 0)
-            XCTAssertNil(client.refreshToken)
-            XCTAssertNil(client.idToken)
-            XCTAssertEqual(client.accessTokenMap.count, 0)
+            // Credentials must stay intact so the caller can retry a complete sign-out with a valid URI.
+            XCTAssertEqual(client.refreshToken, initialRefreshToken)
+            XCTAssertEqual(client.idToken, initialIdToken)
+            XCTAssertEqual(client.accessTokenMap.count, 1)
         }
 
         @MainActor

--- a/Tests/LogtoClientTests/LogtoClient/LogtoClientTests.swift
+++ b/Tests/LogtoClientTests/LogtoClient/LogtoClientTests.swift
@@ -7,10 +7,14 @@ final class LogtoClientTests: XCTestCase {
     let initialRefreshToken = "foo"
     let initialIdToken = "bar"
 
-    func buildClient(withOidcEndpoint endpoint: String = "/oidc_config:good", withToken: Bool = false) -> LogtoClient {
+    func buildClient(
+        withOidcEndpoint endpoint: String = "/oidc_config:good",
+        withToken: Bool = false,
+        session: NetworkSession = NetworkSessionMock.shared
+    ) -> LogtoClient {
         let client = LogtoClient(
             useConfig: try! LogtoConfig(endpoint: endpoint, appId: "foo", usingPersistStorage: false),
-            session: NetworkSessionMock.shared
+            session: session
         )
 
         if withToken {


### PR DESCRIPTION
## Summary
- Treat an invalid `postLogoutRedirectUri` as a pure input-validation failure: return `.invalidRedirectUri` immediately with **no side effects**.
- Keep all local credentials intact so the caller can retry a complete sign-out (token revocation + browser session clear) after fixing the URI.
- Skip the OIDC discovery / token revocation network round-trips on this path.
- Add an iOS sign-out test asserting that an invalid redirect performs no network request and leaves credentials untouched.

## Why
`postLogoutRedirectUri` is validated entirely client-side, so an invalid value is a deterministic developer error — retrying with the same URI will always fail.

Previously this path called `clearCredentials()`, which cleared local tokens and then attempted an OIDC fetch + revoke (with the result discarded). Clearing local credentials there left the client "signed out" locally while the Logto session stayed alive on the provider, and — because the credentials were already gone — the caller could no longer perform a real sign-out even after correcting the URI. Returning early with no side effects lets the caller fix the URI and retry the full flow.

### Note on runtime-failure paths
Runtime-failure paths (e.g. `.unableToFetchOidcConfig`, `.unableToLaunchBrowser`) intentionally keep clearing local credentials. Those are network/runtime failures with no deterministic retry, and revoking the token / clearing the browser session is impossible while the network is down anyway. A user who tapped "sign out" should not remain signed in locally across repeated failures, so the best-effort local clear is kept. This is left unchanged on purpose.

## Tests
- `swift test`
- `xcodebuild test -scheme LogtoSDK-Package -destination 'id=2BEE4CA3-DF73-48BE-BC00-8BF59766379A'`
