### PR TITLE
ci: install iOS simulator runtime for macos-26 runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           set -o pipefail && \
           xcodebuild \
             -scheme "LogtoSDK-Package" \
-            -destination "platform=iOS Simulator,OS=26.2,name=iPhone 17 Pro" \
+            -destination "platform=iOS Simulator,name=iPhone 17 Pro" \
             -enableCodeCoverage=YES \
             -resultBundlePath Logto.xcresult \
             test | \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,12 @@ jobs:
           [ ! -d ".build/" ] && swift run -c release swiftformat ../ --lint || .build/release/swiftformat ../ --lint
         working-directory: ./BuildTools
 
+      - name: Install iOS Simulator runtime
+        run: |
+          xcrun simctl list runtimes
+          xcodebuild -downloadPlatform iOS
+          xcrun simctl list runtimes
+
       - name: Build & Test
         run: |
           set -o pipefail && \


### PR DESCRIPTION
## Summary

The `Main` workflow started failing on `master` after the `macos-latest` runner image migrated to macOS 26 (actions/runner-images#14167). On the new image, iOS Simulator runtimes are no longer pre-installed for the selected Xcode, so `xcodebuild` reports an empty destination list and fails:

> Unable to find a destination matching the provided destination specifier:
> { platform:iOS Simulator, name:iPhone 17 Pro }
> ... error: iOS 26.1 is not installed. Please download and install the platform ...

Fix:
- Add an `Install iOS Simulator runtime` step running `xcodebuild -downloadPlatform iOS` so the runtime exists before the test step (the `simctl list runtimes` calls are kept for diagnostics).
- Drop the hardcoded `OS=26.2` from the destination so `xcodebuild` matches whatever iOS runtime the selected Xcode ships, keeping the device pinned to `iPhone 17 Pro`.

Verified green on this PR (`Install iOS Simulator runtime` + `Build & Test` both pass).

## Testing

N/A — CI configuration change.

## Checklist

N/A — CI-only change in a Swift package (no `.changeset`/unit/integration tests/TSDoc applicable).
